### PR TITLE
Fix some issues on the miner with wandb runs

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -65,6 +65,7 @@ from storage.miner.utils import (
     save_data_to_filesystem,
     load_from_filesystem,
     commit_data_with_seed,
+    init_wandb,
 )
 
 from storage.miner.config import (

--- a/storage/miner/utils.py
+++ b/storage/miner/utils.py
@@ -134,3 +134,37 @@ def compute_subsequent_commitment(data, previous_seed, new_seed, verbose=False):
         bt.logging.debug("type of new_seed :", type(new_seed))
     proof = hash_data(data + previous_seed)
     return hash_data(str(proof).encode("utf-8") + new_seed), proof
+
+def init_wandb(self, reinit=False):
+    """Starts a new wandb run."""
+    tags = [
+        self.wallet.hotkey.ss58_address,
+        storage.__version__,
+        str(storage.__spec_version__),
+        f"netuid_{self.metagraph.netuid}",
+    ]
+
+    if self.config.mock:
+        tags.append("mock")
+
+    wandb_config = {
+        key: copy.deepcopy(self.config.get(key, None))
+        for key in ("neuron", "reward", "netuid", "wandb")
+    }
+    wandb_config["neuron"].pop("full_path", None)
+
+    self.wandb = wandb.init(
+        anonymous="allow",
+        reinit=reinit,
+        project=self.config.wandb.project_name,
+        entity=self.config.wandb.entity,
+        config=wandb_config,
+        mode="offline" if self.config.wandb.offline else "online",
+        dir=self.config.neuron.full_path,
+        tags=tags,
+        notes=self.config.wandb.notes,
+    )
+    bt.logging.success(
+        prefix="Started a new wandb run",
+        sufix=f"<blue> {self.wandb.name} </blue>",
+    )

--- a/storage/miner/utils.py
+++ b/storage/miner/utils.py
@@ -153,7 +153,9 @@ def init_wandb(self, reinit=False):
         key: copy.deepcopy(self.config.get(key, None))
         for key in ("neuron", "reward", "netuid", "wandb")
     }
-    wandb_config["neuron"].pop("full_path", None)
+    
+    if wandb_config["neuron"] is not None:
+        wandb_config["neuron"].pop("full_path", None)
 
     self.wandb = wandb.init(
         anonymous="allow",
@@ -162,7 +164,7 @@ def init_wandb(self, reinit=False):
         entity=self.config.wandb.entity,
         config=wandb_config,
         mode="offline" if self.config.wandb.offline else "online",
-        dir=self.config.neuron.full_path,
+        dir=self.config.neuron.full_path if self.config.neuron is not None else "wandb_logs",
         tags=tags,
         notes=self.config.wandb.notes,
     )

--- a/storage/miner/utils.py
+++ b/storage/miner/utils.py
@@ -19,6 +19,7 @@
 import os
 import json
 import bittensor as bt
+import storage
 
 from ..shared.ecc import (
     ecc_point_to_hex,
@@ -28,7 +29,6 @@ from ..shared.ecc import (
 from ..shared.merkle import (
     MerkleTree,
 )
-
 
 def commit_data_with_seed(committer, data_chunks, n_chunks, seed):
     """

--- a/storage/miner/utils.py
+++ b/storage/miner/utils.py
@@ -18,8 +18,10 @@
 
 import os
 import json
-import bittensor as bt
 import storage
+import wandb
+import copy
+import bittensor as bt
 
 from ..shared.ecc import (
     ecc_point_to_hex,


### PR DESCRIPTION
In main, init_wandb isn't imported or defined within the miner file. The `init_wandb` function defined in `storage/validator/state` expects some data that doesn't exist on the miner, this also fixes those particulars.