### PR TITLE
Release/1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Currently supporting `python>=3.8,<3.11`.
    - [Storage Phase](#storage-phase)
    - [Challenge Phase](#challenge-phase)
    - [Retrieval Phase](#retrieval-phase)
+1. [Reward System](#reward-system)
 1. [Epoch UID Selection](#epoch-uid-selection)
 1. [Installation](#installation)
    - [Install Redis](#install-redis)
@@ -272,6 +273,104 @@ In each phase, cryptographic primitives ensure data integrity and confidentialit
 In each phase, cryptographic primitives like hashing, commitment schemes (e.g., Elliptic Curve Cryptography and Pedersen commitments), and data structures like Merkle trees are employed to ensure the integrity, confidentiality, and availability of the data. The use of seeds and randomness in commitments adds an additional layer of security and ensures that each instance of data storage and retrieval is unique and verifiable. See [here](https://kndrck.co/posts/efficient-merkletrees-zk-proofs/) for more information.
 
 
+## Reward System
+
+In FileTAO's decentralized storage system, optimal behavior is crucial for the overall health and efficiency of the network. Miners play a vital role in maintaining this ecosystem, and their actions directly impact their rewards and standing within the subnet. We have implemented a tier-based reward system to encourage proper behavior, successful challenge completions, and consistent performance.
+
+Failing to pass either challenge or retrieval verifications incur negative rewards. This is doubly destructive, as rolling statistics are continuously logged to periodically compute which tier a given miner hotkey belongs to. When a miner achieves the threshold for the next tier, the rewards that miner recieves proportionally increase. Conversely, when a miner drops below the threshold of the previous tier, that miner's rewards are slashed such that they recieve rewards proportionally to the immediately lower tier.
+
+
+#### Tier System:
+The tier system classifies miners into five distinct categories, each with specific requirements and storage limits. These tiers are designed to reward miners based on their performance, reliability, and the total volume of data they can store.
+
+1. 🎇 **Super Saiyan Tier:** 
+   - **Storage Limit:** 1 Exabyte (EB)
+   - **Store Success Rate:** 99.9% (1/1000 chance of failure)
+   - **Retrieval Success Rate:** 99.9%
+   - **Challenge Success Rate:** 99.9%
+   - **Reward Factor:** 2.0 (200% rewards)
+
+2. 💎 **Diamond Tier:**
+   - **Storage Limit:** 1 Petabyte (PB)
+   - **Store Success Rate:** 99% (1/100 chance of failure)
+   - **Retrieval Success Rate:** 99%
+   - **Challenge Success Rate:** 99%
+   - **Reward Factor:** 1.0 (100% rewards)
+
+3. 🥇 **Gold Tier:**
+   - **Storage Limit:** 100 Terabytes (TB)
+   - **Store Success Rate:** 97.5% (1/50 chance of failure)
+   - **Retrieval Success Rate:** 97.5%
+   - **Challenge Success Rate:** 97.5%
+   - **Reward Factor:** 0.888 (88.8% rewards)
+
+4. 🥈 **Silver Tier:**
+   - **Storage Limit:** 10 Terabytes (TB)
+   - **Store Success Rate:** 95% (1/20 chance of failure)
+   - **Retrieval Success Rate:** 95%
+   - **Challenge Success Rate:** 95%
+   - **Reward Factor:** 0.555 (55.5% rewards)
+
+5. 🥉 **Bronze Tier:**
+   - **Storage Limit:** 1 Terabyte (TB)
+   - **Store Success Rate:** Not specifically defined for this tier
+   - **Retrieval Success Rate:** Not specifically defined for this tier
+   - **Challenge Success Rate:** Not specifically defined for this tier
+   - **Reward Factor:** 0.333 (33.3% rewards)
+
+#### Importance of Tier System:
+- **Encourages High Performance:** Higher tiers reward miners with greater benefits, motivating them to maintain high success rates.
+- **Enhances Network Reliability:** The tier system ensures that only the most reliable and efficient miners handle significant volumes of data, enhancing the overall reliability of the network.
+- **Fair Reward Distribution:** The reward factors are proportional to the miners' tier, ensuring a fair distribution of rewards based on performance.
+
+#### Maintaining and Advancing Tiers:
+- To advance to a higher tier, miners must consistently achieve the required success rates in their operations.
+- Periodic evaluations are conducted to ensure miners maintain the necessary performance standards to stay in their respective tiers.
+
+#### Conclusion:
+The tier system in FileTAO's decentralized storage network plays a pivotal role in ensuring the network's efficiency and reliability. By setting clear performance benchmarks and rewarding miners accordingly, the system fosters a competitive yet fair environment. This encourages continuous improvement among miners, ultimately leading to a robust and trustworthy decentralized storage solution.
+
+
+**Why Optimal Behavior Matters:**
+1. **Reliability:** Miners who consistently store, retrieve, and pass challenges with high success rates ensure the reliability and integrity of the network.
+2. **Trust:** High-performing miners build trust in the network, attracting more users and increasing the overall value of the system.
+3. **Efficiency:** Optimal behavior leads to a more efficient network, reducing the likelihood of data loss and ensuring fast, reliable access to stored information.
+
+**Tier-Based Reward System:**
+- **Tiers:** We classify miners into four tiers – Diamond, Gold, Silver, and Bronze – based on their performance metrics.
+- **Performance Metrics:** These include the success rate in storage, retrieval, and challenge tasks, as well as the total number of successful operations.
+- **Higher Rewards for Higher Tiers:** Miners in higher tiers receive a greater proportion of the rewards, reflecting their superior performance and contribution to the network.
+
+**Moving Up Tiers:**
+- To ascend to a higher tier, a miner must maintain high success rates and achieve a set number of total successes.
+- This progression system incentivizes continuous improvement and excellence in mining operations.
+
+**Graphical Representation:**
+- The graph below illustrates how rewards increase as miners advance through the tiers. It visually represents the potential growth in earnings as miners optimize their operations and maintain high standards of performance.
+
+![bond-curve](assets/bonding.jpg)
+
+The tier-based reward system is designed to promote optimal behavior among miners, ensuring the health and efficiency of the decentralized storage network. By aligning miners' interests with those of the network, we create a robust, trustworthy, and efficient storage solution.
+
+### Speed and Reliability in Decentralized Storage Mining
+
+In the context of FileTAO's decentralized storage system, speed and reliability are critical factors that significantly influence the performance and reputation of miners. These factors not only affect the efficiency of data storage and retrieval but also play a crucial role in the overall user experience and the robustness of the network.
+
+#### Importance of Speed:
+1. **Quick Data Access:** Fast response times in data storage and retrieval operations are essential for a seamless user experience. Miners with quicker response times enhance the network's ability to serve data efficiently.
+2. **Improved Network Performance:** Speedy processing of tasks contributes to the overall performance of the network, reducing bottlenecks and ensuring smooth data flow.
+3. **Advantage in Reward Scaling:** The implemented reward scaling mechanisms favor faster response times. Miners who consistently provide quick services are likely to receive higher rewards due to better performance metrics.
+
+#### Importance of Reliability:
+1. **Data Integrity:** Reliable storage and retrieval ensure that data remains intact and accessible when needed. This is vital for maintaining the trust of users who rely on the network for data storage.
+2. **Challenge Success Rate:** A high success rate in passing challenges signifies a miner's reliability. It shows their commitment to maintaining the network's integrity and their capability to meet the required standards.
+3. **Tier Advancement and Stability:** Reliable miners have a better chance of advancing to higher tiers and maintaining their position. This stability is rewarded with increased earning potential and recognition within the network.
+
+#### Reward Scaling Mechanisms:
+1. **Sigmoid and Min-Max Scaling:** The reward scaling is based on response times, using either an adjusted sigmoid function or min-max normalization. This approach rewards faster and more reliable miners, aligning their incentives with the network's goals.
+2. **Tier-Based Reward Factors:** Each tier has an associated reward factor, which determines the proportion of rewards received by the miner. Higher tiers, achieved through consistent performance, offer greater rewards.
+
+
 ## Epoch UID selection
 Miners are chosen pseudorandomly using the current block hash as a random seed. This allows for public verification of which miners are selected for each challenge round (3 blocks).
 
@@ -409,34 +508,6 @@ pm2 start /home/user/storage-subnet/neurons/miner.py --interpreter /home/user/mi
 - `--wandb.notes`: Notes to add to the WandB run. Default: "".
 
 These options allow you to configure the miner's behavior, database connections, blacklist/whitelist settings, priority handling, and integration with monitoring tools like WandB. Adjust these settings based on your mining setup and requirements.
-
-
-#### Optimal Behavior and Reward System in Decentralized Storage Mining
-
-In FileTAO's decentralized storage system, optimal behavior is crucial for the overall health and efficiency of the network. Miners play a vital role in maintaining this ecosystem, and their actions directly impact their rewards and standing within the subnet. We have implemented a tier-based reward system to encourage proper behavior, successful challenge completions, and consistent performance.
-
-Failing to pass either challenge or retrieval verifications incur negative rewards. This is doubly destructive, as rolling statistics are continuously logged to periodically compute which tier a given miner hotkey belongs to. When a miner achieves the threshold for the next tier, the rewards that miner recieves proportionally increase. Conversely, when a miner drops below the threshold of the previous tier, that miner's rewards are slashed such that they recieve rewards proportionally to the immediately lower tier.
-
-**Why Optimal Behavior Matters:**
-1. **Reliability:** Miners who consistently store, retrieve, and pass challenges with high success rates ensure the reliability and integrity of the network.
-2. **Trust:** High-performing miners build trust in the network, attracting more users and increasing the overall value of the system.
-3. **Efficiency:** Optimal behavior leads to a more efficient network, reducing the likelihood of data loss and ensuring fast, reliable access to stored information.
-
-**Tier-Based Reward System:**
-- **Tiers:** We classify miners into four tiers – Diamond, Gold, Silver, and Bronze – based on their performance metrics.
-- **Performance Metrics:** These include the success rate in storage, retrieval, and challenge tasks, as well as the total number of successful operations.
-- **Higher Rewards for Higher Tiers:** Miners in higher tiers receive a greater proportion of the rewards, reflecting their superior performance and contribution to the network.
-
-**Moving Up Tiers:**
-- To ascend to a higher tier, a miner must maintain high success rates and achieve a set number of total successes.
-- This progression system incentivizes continuous improvement and excellence in mining operations.
-
-**Graphical Representation:**
-- The graph below illustrates how rewards increase as miners advance through the tiers. It visually represents the potential growth in earnings as miners optimize their operations and maintain high standards of performance.
-
-![bond-curve](assets/bonding.jpg)
-
-The tier-based reward system is designed to promote optimal behavior among miners, ensuring the health and efficiency of the decentralized storage network. By aligning miners' interests with those of the network, we create a robust, trustworthy, and efficient storage solution.
 
 
 ### Running a validator

--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ BT_COLD_PW_DEFAULT=<YOUR_PW_HERE> pm2 start /home/user/storage-subnet/neurons/va
 - `--neuron.blocks_per_step`: Blocks before a step is taken in the mining process. Default: 3.
 - `--neuron.events_retention_size`: File size for retaining event logs (e.g., "2 GB"). Default: "2 GB".
 - `--neuron.dont_save_events`: If set, event logs will not be saved to a file. Default: False.
-- `--neuron.vpermit_tao_limit`: The maximum TAO allowed for querying a validator with a vpermit. Default: 4096.
+- `--neuron.vpermit_tao_limit`: The maximum TAO allowed for querying a validator with a vpermit. Default: 500.
 - `--neuron.verbose`: If set, detailed verbose logs will be printed. Default: False.
 - `--neuron.log_responses`: If set, all responses will be logged. Note: These logs can be extensive. Default: False.
 - `--neuron.data_ttl`: The number of blocks before stored data expires. Default: 50000 (approximately 7 days).

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ The tier system classifies miners into five distinct categories, each with speci
    - **Store Success Rate:** 99.9% (1/1000 chance of failure)
    - **Retrieval Success Rate:** 99.9%
    - **Challenge Success Rate:** 99.9%
+   - **Minimum Successes Required:** 100,000
    - **Reward Factor:** 2.0 (200% rewards)
 
 2. 💎 **Diamond Tier:**
@@ -295,6 +296,7 @@ The tier system classifies miners into five distinct categories, each with speci
    - **Store Success Rate:** 99% (1/100 chance of failure)
    - **Retrieval Success Rate:** 99%
    - **Challenge Success Rate:** 99%
+   - **Minimum Successes Required:** 50,000
    - **Reward Factor:** 1.0 (100% rewards)
 
 3. 🥇 **Gold Tier:**
@@ -302,6 +304,7 @@ The tier system classifies miners into five distinct categories, each with speci
    - **Store Success Rate:** 97.5% (1/50 chance of failure)
    - **Retrieval Success Rate:** 97.5%
    - **Challenge Success Rate:** 97.5%
+   - **Minimum Successes Required:** 5,000
    - **Reward Factor:** 0.888 (88.8% rewards)
 
 4. 🥈 **Silver Tier:**
@@ -309,6 +312,7 @@ The tier system classifies miners into five distinct categories, each with speci
    - **Store Success Rate:** 95% (1/20 chance of failure)
    - **Retrieval Success Rate:** 95%
    - **Challenge Success Rate:** 95%
+   - **Minimum Successes Required:** 1,000
    - **Reward Factor:** 0.555 (55.5% rewards)
 
 5. 🥉 **Bronze Tier:**
@@ -316,6 +320,7 @@ The tier system classifies miners into five distinct categories, each with speci
    - **Store Success Rate:** Not specifically defined for this tier
    - **Retrieval Success Rate:** Not specifically defined for this tier
    - **Challenge Success Rate:** Not specifically defined for this tier
+   - **Minimum Successes Required:** Not specifically defined for this tier
    - **Reward Factor:** 0.333 (33.3% rewards)
 
 #### Importance of Tier System:

--- a/neurons/api.py
+++ b/neurons/api.py
@@ -300,7 +300,7 @@ class neuron:
         # If debug mode, whitelist everything (NOT RECOMMENDED)
         if self.config.api.debug:
             return False, "Debug all whitelisted"
-        
+
         # Otherwise, reject.
         return (
             True,

--- a/neurons/api.py
+++ b/neurons/api.py
@@ -45,13 +45,10 @@ from storage.validator.network import (
     ping_uids,
 )
 
-from storage.validator.database import (
-    retrieve_encryption_payload
-)
+from storage.validator.database import retrieve_encryption_payload
 
-from storage.validator.encryption import (
-    decrypt_data_with_private_key
-)
+from storage.validator.encryption import decrypt_data_with_private_key
+
 
 def MockDendrite():
     pass
@@ -374,7 +371,9 @@ class neuron:
         bt.logging.debug(f"returning user payload: {user_encryption_payload}")
         synapse.encrypted_data = base64.b64encode(user_encryption_payload)
         synapse.encryption_payload = (
-            json.dumps(user_encryption_payload) if isinstance(user_encryption_payload, dict) else user_encryption_payload
+            json.dumps(user_encryption_payload)
+            if isinstance(user_encryption_payload, dict)
+            else user_encryption_payload
         )
         return synapse
 

--- a/neurons/api.py
+++ b/neurons/api.py
@@ -297,14 +297,15 @@ class neuron:
         if synapse.dendrite.hotkey in self.top_n_validators:
             return False, f"Hotkey {synapse.dendrite.hotkey} in top n% stake."
 
-        # Otherwise, reject.
+        # If debug mode, whitelist everything (NOT RECOMMENDED)
         if self.config.api.debug:
             return False, "Debug all whitelisted"
-        return False, ""
-        # return (
-        #     True,
-        #     f"Hotkey {synapse.dendrite.hotkey} not whitelisted or in top n% stake.",
-        # )
+        
+        # Otherwise, reject.
+        return (
+            True,
+            f"Hotkey {synapse.dendrite.hotkey} not whitelisted or in top n% stake.",
+        )
 
     async def store_priority(self, synapse: protocol.StoreUser) -> float:
         caller_uid = self.metagraph.hotkeys.index(
@@ -376,14 +377,15 @@ class neuron:
         if synapse.dendrite.hotkey in self.top_n_validators:
             return False, f"Hotkey {synapse.dendrite.hotkey} in top n% stake."
 
-        # Otherwise, reject.
+        # If debug mode, whitelist everything (NOT RECOMMENDED)
         if self.config.api.debug:
             return False, "Debug all whitelisted."
-        return False, ""
-        # return (
-        #     True,
-        #     f"Hotkey {synapse.dendrite.hotkey} not whitelisted or in top n% stake.",
-        # )
+
+        # Otherwise, reject.
+        return (
+            True,
+            f"Hotkey {synapse.dendrite.hotkey} not whitelisted or in top n% stake.",
+        )
 
     async def retrieve_priority(self, synapse: protocol.RetrieveUser) -> float:
         caller_uid = self.metagraph.hotkeys.index(

--- a/neurons/api.py
+++ b/neurons/api.py
@@ -114,7 +114,7 @@ class neuron:
             hotkey=self.config.neuron.encryption_hotkey,
         )
         self.encryption_wallet.create_if_non_existent(coldkey_use_password=False)
-        self.encrpytion_wallet.coldkey  # Unlock the coldkey.
+        self.encryption_wallet.coldkey  # Unlock the coldkey.
 
         # Init metagraph.
         bt.logging.debug("loading metagraph")

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -50,12 +50,7 @@ from storage.shared.merkle import (
     MerkleTree,
 )
 
-from storage.shared.utils import (
-    b64_encode,
-    b64_decode,
-    chunk_data,
-    safe_key_search
-)
+from storage.shared.utils import b64_encode, b64_decode, chunk_data, safe_key_search
 
 from storage.miner import (
     run,
@@ -84,6 +79,7 @@ from storage.miner.database import (
     get_all_filepaths,
     get_total_storage_used,
 )
+
 
 class miner:
     @classmethod

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -124,7 +124,7 @@ class neuron:
             hotkey=self.config.neuron.encryption_hotkey,
         )
         self.encryption_wallet.create_if_non_existent(coldkey_use_password=False)
-        self.encrpytion_wallet.coldkey  # Unlock for testing
+        self.encrpytion_wallet.coldkey  # Unlock the coldkey.
 
         # Init metagraph.
         bt.logging.debug("loading metagraph")

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -119,12 +119,13 @@ class neuron:
         bt.logging.debug(f"wallet: {str(self.wallet)}")
 
         # Setup dummy wallet for encryption purposes. No password needed.
-        self.encryption_wallet = bt.wallet(
-            name=self.config.neuron.encryption_wallet_name,
-            hotkey=self.config.neuron.encryption_hotkey,
+        self.encryption_wallet = setup_encryption_wallet(
+            wallet_name=self.config.neuron.encryption_wallet_name,
+            wallet_hotkey=self.config.neuron.encryption_hotkey,
+            password=self.config.neuron.encryption_password,
         )
         self.encryption_wallet.create_if_non_existent(coldkey_use_password=False)
-        self.encrpytion_wallet.coldkey  # Unlock the coldkey.
+        self.encryption_wallet.coldkey  # Unlock the coldkey.
 
         # Init metagraph.
         bt.logging.debug("loading metagraph")

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -52,8 +52,10 @@ from storage.validator.forward import forward
 from storage.validator.rebalance import rebalance_data
 from storage.validator.encryption import setup_encryption_wallet
 
+
 def MockDendrite():
     pass
+
 
 class neuron:
     """

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -50,6 +50,7 @@ from storage.validator.weights import (
 from storage.validator.database import purge_challenges_for_all_hotkeys
 from storage.validator.forward import forward
 from storage.validator.rebalance import rebalance_data
+from storage.validator.encryption import setup_encryption_wallet
 
 
 class neuron:
@@ -120,12 +121,13 @@ class neuron:
 
         # Setup dummy wallet for encryption purposes. No password needed.
         self.encryption_wallet = setup_encryption_wallet(
-            wallet_name=self.config.neuron.encryption_wallet_name,
-            wallet_hotkey=self.config.neuron.encryption_hotkey,
-            password=self.config.neuron.encryption_password,
+            wallet_name=self.config.encryption.wallet_name,
+            wallet_hotkey=self.config.encryption.hotkey,
+            password=self.config.encryption.password,
         )
         self.encryption_wallet.create_if_non_existent(coldkey_use_password=False)
         self.encryption_wallet.coldkey  # Unlock the coldkey.
+        bt.logging.info(f"loading encryption wallet {self.encryption_wallet}")
 
         # Init metagraph.
         bt.logging.debug("loading metagraph")

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -103,11 +103,11 @@ class neuron:
         )
         bt.logging.debug(str(self.subtensor))
 
-        # Init wallet.
+        # Init validator wallet.
         bt.logging.debug("loading wallet")
         self.wallet = bt.wallet(config=self.config)
-        self.wallet.coldkey  # Unlock for testing
         self.wallet.create_if_non_existent()
+
         if not self.config.wallet._mock:
             if not self.subtensor.is_hotkey_registered_on_subnet(
                 hotkey_ss58=self.wallet.hotkey.ss58_address, netuid=self.config.netuid
@@ -117,6 +117,14 @@ class neuron:
                 )
 
         bt.logging.debug(f"wallet: {str(self.wallet)}")
+
+        # Setup dummy wallet for encryption purposes. No password needed.
+        self.encryption_wallet = bt.wallet(
+            name=self.config.neuron.encryption_wallet_name,
+            hotkey=self.config.neuron.encryption_hotkey,
+        )
+        self.encryption_wallet.create_if_non_existent(coldkey_use_password=False)
+        self.encrpytion_wallet.coldkey  # Unlock for testing
 
         # Init metagraph.
         bt.logging.debug("loading metagraph")

--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/storage/cli/storecommand.py
+++ b/storage/cli/storecommand.py
@@ -273,7 +273,7 @@ class StoreData:
         store_parser.add_argument(
             "--stake_limit",
             type=float,
-            default=1000,
+            default=500,
             help="Stake limit to exclude validator axons to query.",
         )
         store_parser.add_argument(

--- a/storage/cli/storecommand.py
+++ b/storage/cli/storecommand.py
@@ -290,7 +290,7 @@ class StoreData:
         store_parser.add_argument(
             "--neuron.vpermit_tao_limit",
             type=int,
-            default=2000,
+            default=500,
             help="Tao limit for the validator permit.",
         )
         store_parser.add_argument(

--- a/storage/validator/challenge.py
+++ b/storage/validator/challenge.py
@@ -130,7 +130,7 @@ async def handle_challenge(self, uid: int) -> typing.Tuple[bool, protocol.Challe
         deserialize=True,
         timeout=self.config.neuron.challenge_timeout,
     )
-    verified = verify_challenge_with_seed(response[0])
+    verified = verify_challenge_with_seed(response[0], synapse.seed)
 
     if verified:
         data["prev_seed"] = synapse.seed

--- a/storage/validator/config.py
+++ b/storage/validator/config.py
@@ -352,18 +352,6 @@ def add_args(cls, parser):
     parser.add_argument(
         "--mock", action="store_true", help="Mock all items.", default=False
     )
-    parser.add_argument(
-        "--neuron.nsfw_off",
-        action="store_true",
-        help="Dont apply the nsfw reward model",
-        default=False,
-    )
-    parser.add_argument(
-        "--neuron.mock_dendrite_pool",
-        action="store_true",
-        help="Dont download the dendrite pool.",
-        default=False,
-    )
 
     # API specific
     parser.add_argument(

--- a/storage/validator/config.py
+++ b/storage/validator/config.py
@@ -156,6 +156,12 @@ def add_args(cls, parser):
         help="Number of steps before calling monitor for down uids.",
     )
     parser.add_argument(
+        "--neuron.monitor_sample_size",
+        type=int,
+        default=20,
+        help="Number of miners to monitor each interval.",
+    )
+    parser.add_argument(
         "--neuron.max_failed_pings",
         type=int,
         default=10,

--- a/storage/validator/config.py
+++ b/storage/validator/config.py
@@ -219,7 +219,7 @@ def add_args(cls, parser):
         "--neuron.challenge_timeout",
         type=float,
         help="Challenge data query timeout.",
-        default=20,
+        default=30,
     )
     parser.add_argument(
         "--neuron.retrieve_timeout",

--- a/storage/validator/config.py
+++ b/storage/validator/config.py
@@ -398,6 +398,12 @@ def add_args(cls, parser):
         help="The hotkey name of the wallet to use for encryption.",
         default="core_storage_hotkey",
     )
+    parser.add_argument(
+        "--encryption.password",
+        type=str,
+        help="The password of the wallet to use for encryption.",
+        default="dummy_password",
+    )
 
 
 def config(cls):

--- a/storage/validator/config.py
+++ b/storage/validator/config.py
@@ -246,12 +246,6 @@ def add_args(cls, parser):
         default=3,
     )
     parser.add_argument(
-        "--neuron.monitor_step_length",
-        type=int,
-        help="Number of steps before calling monitor for down uids.",
-        default=5,
-    )
-    parser.add_argument(
         "--neuron.events_retention_size",
         type=str,
         help="Events retention size.",

--- a/storage/validator/config.py
+++ b/storage/validator/config.py
@@ -255,7 +255,7 @@ def add_args(cls, parser):
         "--neuron.vpermit_tao_limit",
         type=int,
         help="The maximum number of TAO allowed to query a validator with a vpermit.",
-        default=2000,
+        default=500,
     )
     parser.add_argument(
         "--neuron.verbose",

--- a/storage/validator/config.py
+++ b/storage/validator/config.py
@@ -388,7 +388,7 @@ def add_args(cls, parser):
         "--api.ping_timeout",
         type=int,
         help="Ping data query timeout.",
-        default=2,
+        default=5,
     )
     parser.add_argument(
         "--api.whitelisted_hotkeys",

--- a/storage/validator/config.py
+++ b/storage/validator/config.py
@@ -391,6 +391,20 @@ def add_args(cls, parser):
         help="If set, we whitelist by default to test easily.",
     )
 
+    # Encryption wallet
+    parser.add_argument(
+        "--encryption.wallet_name",
+        type=str,
+        help="The name of the wallet to use for encryption.",
+        default="core_storage_coldkey",
+    )
+    parser.add_argument(
+        "--encryption.wallet_hotkey",
+        type=str,
+        help="The hotkey name of the wallet to use for encryption.",
+        default="core_storage_hotkey",
+    )
+
 
 def config(cls):
     parser = argparse.ArgumentParser()

--- a/storage/validator/config.py
+++ b/storage/validator/config.py
@@ -150,6 +150,12 @@ def add_args(cls, parser):
         help="Number of steps before computing and logging all stats.",
     )
     parser.add_argument(
+        "--neuron.monitor_step_length",
+        type=int,
+        default=5,
+        help="Number of steps before calling monitor for down uids.",
+    )
+    parser.add_argument(
         "--neuron.max_failed_pings",
         type=int,
         default=10,

--- a/storage/validator/config.py
+++ b/storage/validator/config.py
@@ -134,7 +134,7 @@ def add_args(cls, parser):
     parser.add_argument(
         "--neuron.challenge_sample_size",
         type=int,
-        default=20,
+        default=10,
         help="Number of miners to challenge at a time. Target is ~90 miners per epoch.",
     )
     parser.add_argument(

--- a/storage/validator/distribute.py
+++ b/storage/validator/distribute.py
@@ -26,15 +26,7 @@ from pprint import pformat
 from Crypto.Random import get_random_bytes, random
 
 from storage import protocol
-from storage.validator.verify import (
-    verify_store_with_seed,
-    verify_challenge_with_seed,
-    verify_retrieve_with_seed,
-)
-from storage.validator.database import (
-    update_metadata_for_data_hash,
-    get_ordered_metadata,
-)
+from storage.validator.database import get_ordered_metadata
 
 from .store import store_broadband
 from .retrieve import retrieve_broadband

--- a/storage/validator/encryption.py
+++ b/storage/validator/encryption.py
@@ -469,9 +469,9 @@ def test_serialize_nacl_encrypted_message(wallet: bt.wallet):
 
 
 def setup_encryption_wallet(
-    password="dummy_password",
     wallet_name="encryption",
     wallet_hotkey="encryption",
+    password="dummy_password",
     n_words=12,
     use_encryption=False,
     overwrite=False,

--- a/storage/validator/encryption.py
+++ b/storage/validator/encryption.py
@@ -321,92 +321,6 @@ decrypt_data = decrypt_data_and_deserialize
 decrypt_data_with_private_key = decrypt_data_and_deserialize_with_coldkey_private_key
 
 
-def test_encrypt_decrypt_small_data(wallet: bt.wallet):
-    """
-    A test function to demonstrate the encryption and decryption of a small string using the wallet-based encryption scheme.
-
-    This function is intended for testing and demonstration purposes. It shows how to encrypt and decrypt a small string
-    of data using the `encrypt_data_with_wallet` and `decrypt_data_with_wallet` functions.
-    """
-
-    data_to_encrypt = b"Your small string here"
-
-    # Encrypt
-    encrypted_data, encryption_payload = encrypt_data(data_to_encrypt, wallet)
-
-    # Decrypt
-    decrypted_data = decrypt_data(encrypted_data, encryption_payload, wallet)
-
-    print("Original:", data_to_encrypt)
-    print("Encrypted:", encrypted_data)
-    print("Decrypted:", decrypted_data)
-
-
-def test_encrypt_decrypt_large_data(wallet: bt.wallet):
-    """
-    A test function to demonstrate the encryption and decryption of a large amount of data using AES and wallet-based encryption.
-
-    This function is intended for testing and demonstration purposes. It shows how to encrypt and decrypt large data
-    using the `encrypt_data_with_aes_and_serialize` and `decrypt_data_and_deserialize` functions.
-    """
-
-    # Encrypting large data
-    data_to_encrypt = (str(["LARGE DATA"] * int(1e8))).encode()
-    encrypted_data, encryption_payload = encrypt_data_with_aes_and_serialize(
-        data_to_encrypt, wallet
-    )
-
-    # Decrypting data
-    decrypted_data = decrypt_data_and_deserialize(
-        encrypted_data, encryption_payload, wallet
-    )
-
-    print("Original Data:", data_to_encrypt)
-    print("Decrypted Data:", decrypted_data)
-
-
-# Timing function for large data encryption and decryption
-def time_encrypt_decrypt_large_data(wallet: bt.wallet, exp=9):
-    """
-    Measures and prints the time taken to encrypt and decrypt a large amount of data.
-
-    Args:
-        exp (int, optional): Exponent to determine the size of the data. Defaults to 9 (1GB).
-
-    This function is used for performance testing. It generates a large amount of random data,
-    encrypts it using `encrypt_data_with_aes_and_serialize`, and then decrypts it using
-    `decrypt_data_and_deserialize`. The time taken for each operation is printed out.
-    """
-
-    wallet.coldkey  # unlock wallet before timing
-
-    # Generate large data for test
-    data_to_encrypt = os.urandom(10**exp)  # 10**9 => 1000MB of random data
-
-    # Start timing encryption
-    start_time = time.time()
-    encrypted_data, encryption_payload = encrypt_data_with_aes_and_serialize(
-        data_to_encrypt, wallet
-    )
-    encryption_time = time.time() - start_time
-
-    # Start timing decryption
-    start_time = time.time()
-    decrypted_data = decrypt_data_and_deserialize(
-        encrypted_data, encryption_payload, wallet
-    )
-    decryption_time = time.time() - start_time
-
-    # Output timings
-    print(f"Encryption Time: {encryption_time} seconds")
-    print(f"Decryption Time: {decryption_time} seconds")
-
-    # Optional: Verify if the decrypted data matches the original
-    assert (
-        decrypted_data == data_to_encrypt
-    ), "Decrypted data does not match the original"
-
-
 def serialize_nacl_encrypted_message(encrypted_message: EncryptedMessage) -> str:
     """
     Serializes an EncryptedMessage object to a JSON string.
@@ -447,25 +361,6 @@ def deserialize_nacl_encrypted_message(serialized_data: str) -> EncryptedMessage
     ciphertext = HexEncoder.decode(data["ciphertext"].encode("utf-8"))
     combined = nonce + ciphertext
     return EncryptedMessage._from_parts(nonce, ciphertext, combined)
-
-
-def test_serialize_nacl_encrypted_message(wallet: bt.wallet):
-    encrypted_msg = encrypt_data_with_wallet(b"Hello World!", wallet)
-
-    # Assuming 'encrypted_msg' is an EncryptedMessage object
-    serialized = serialize_nacl_encrypted_message(encrypted_msg)
-    print("Serialized data:", serialized)
-
-    # Deserializing back to an EncryptedMessage object
-    deserialized_msg = deserialize_nacl_encrypted_message(serialized)
-    print("Deserialized message nonce:", deserialized_msg.nonce)
-    print("Deserialized message ciphertext:", deserialized_msg.ciphertext)
-
-    # Assertions to verify equivalence
-    assert deserialized_msg.nonce == encrypted_msg.nonce, "Nonces do not match"
-    assert (
-        deserialized_msg.ciphertext == encrypted_msg.ciphertext
-    ), "Ciphertexts do not match"
 
 
 def setup_encryption_wallet(

--- a/storage/validator/forward.py
+++ b/storage/validator/forward.py
@@ -144,4 +144,4 @@ async def forward(self):
         writer.writerow(total_storage_time)
 
     forward_time = time.time() - start
-    bt.logging.info(f"forward step time: {forward_time}s")
+    bt.logging.info(f"forward step time: {forward_time:.2f}s")

--- a/storage/validator/forward.py
+++ b/storage/validator/forward.py
@@ -43,6 +43,9 @@ from .network import monitor
 async def forward(self):
     bt.logging.info(f"forward step: {self.step}")
 
+    # Record forward time
+    start = time.time()
+
     if self.step % self.config.neuron.store_step_length == 0:
         # Store some random data
         bt.logging.info("initiating store random")
@@ -139,3 +142,6 @@ async def forward(self):
 
         # Write the data row
         writer.writerow(total_storage_time)
+
+    forward_time = time.time() - start
+    bt.logging.info(f"forward step time: {forward_time}s")

--- a/storage/validator/network.py
+++ b/storage/validator/network.py
@@ -181,8 +181,8 @@ async def monitor(self):
     occur. If a UID fails too many times, remove it from the
     list of UIDs to ping.
     """
-    # Ping all UIDs
-    query_uids = get_available_uids(self)
+    # Ping current subset of UIDs
+    query_uids = get_available_query_miners(self, k=self.config.neuron.monitor_sample_size)
     _, failed_uids = await ping_uids(self, query_uids)
 
     down_uids = []

--- a/storage/validator/network.py
+++ b/storage/validator/network.py
@@ -182,7 +182,8 @@ async def monitor(self):
     list of UIDs to ping.
     """
     # Ping all UIDs
-    _, failed_uids = await ping_uids(self, self.metagraph.uids.tolist())
+    query_uids = get_available_uids(self)
+    _, failed_uids = await ping_uids(self, query_uids)
 
     down_uids = []
     for uid in failed_uids:

--- a/storage/validator/network.py
+++ b/storage/validator/network.py
@@ -182,7 +182,7 @@ async def monitor(self):
     list of UIDs to ping.
     """
     # Ping current subset of UIDs
-    query_uids = get_available_query_miners(
+    query_uids = await get_available_query_miners(
         self, k=self.config.neuron.monitor_sample_size
     )
     _, failed_uids = await ping_uids(self, query_uids)

--- a/storage/validator/network.py
+++ b/storage/validator/network.py
@@ -182,7 +182,9 @@ async def monitor(self):
     list of UIDs to ping.
     """
     # Ping current subset of UIDs
-    query_uids = get_available_query_miners(self, k=self.config.neuron.monitor_sample_size)
+    query_uids = get_available_query_miners(
+        self, k=self.config.neuron.monitor_sample_size
+    )
     _, failed_uids = await ping_uids(self, query_uids)
 
     down_uids = []
@@ -205,7 +207,7 @@ async def monitor(self):
                 task_type="monitor",
                 database=self.database,
             )
-            rewards[i] = -0.1
+            rewards[i] = -0.05
 
         scattered_rewards: torch.FloatTensor = self.moving_averaged_scores.scatter(
             0, torch.tensor(down_uids).to(self.device), rewards

--- a/storage/validator/retrieve.py
+++ b/storage/validator/retrieve.py
@@ -162,6 +162,7 @@ async def retrieve_data(
         len(response_tuples), dtype=torch.float32
     ).to(self.device)
 
+    decoded_data = b""
     for idx, (uid, (response, data_hash)) in enumerate(zip(uids, response_tuples)):
         hotkey = self.metagraph.hotkeys[uid]
 
@@ -169,7 +170,6 @@ async def retrieve_data(
             bt.logging.debug(f"No response: skipping retrieve for uid {uid}")
             continue  # We don't have any data for this hotkey, skip it.
 
-        decoded_data = b""
         try:
             decoded_data = base64.b64decode(response.data)
         except Exception as e:

--- a/storage/validator/retrieve.py
+++ b/storage/validator/retrieve.py
@@ -96,7 +96,7 @@ async def handle_retrieve(self, uid):
     except Exception as e:
         bt.logging.error(f"Failed to retrieve data from UID: {uid} with error: {e}")
 
-    return response[0], data_hash
+    return response[0], data_hash, synapse.seed
 
 
 async def retrieve_data(
@@ -163,7 +163,9 @@ async def retrieve_data(
     ).to(self.device)
 
     decoded_data = b""
-    for idx, (uid, (response, data_hash)) in enumerate(zip(uids, response_tuples)):
+    for idx, (uid, (response, data_hash, seed)) in enumerate(
+        zip(uids, response_tuples)
+    ):
         hotkey = self.metagraph.hotkeys[uid]
 
         if response == None:
@@ -202,7 +204,7 @@ async def retrieve_data(
             )
             continue
 
-        success = verify_retrieve_with_seed(response)
+        success = verify_retrieve_with_seed(response, seed)
         if not success:
             bt.logging.error(
                 f"data verification failed! {pformat(response.axon.dict())}"
@@ -343,7 +345,7 @@ async def retrieve_broadband(self, full_hash: str):
             event.best_uid = event.uids[best_index]
             event.best_hotkey = self.metagraph.hotkeys[event.best_uid]
 
-        return responses
+        return responses, synapse.seed
 
     # Get the chunks you need to reconstruct IN order
     ordered_metadata = await get_ordered_metadata(full_hash, self.database)
@@ -377,12 +379,12 @@ async def retrieve_broadband(self, full_hash: str):
 
         chunks = {}
         # TODO: make these asyncio tasks and use .to_thread() to avoid blocking
-        for i, response_group in enumerate(responses):
+        for i, (response_group, seed) in enumerate(responses):
             for response in response_group:
                 if response.dendrite.status_code != 200:
                     bt.logging.debug(f"failed response: {response.dendrite.dict()}")
                     continue
-                verified = verify_retrieve_with_seed(response)
+                verified = verify_retrieve_with_seed(response, seed)
                 if verified:
                     # Add to final chunks dict
                     if i not in list(chunks.keys()):

--- a/storage/validator/reward.py
+++ b/storage/validator/reward.py
@@ -17,11 +17,24 @@
 # DEALINGS IN THE SOFTWARE.
 
 
+import sys
 import torch
 import numpy as np
 import bittensor as bt
-
+from bittensor import Synapse
+from pprint import pformat
 from typing import Union, List
+
+from .verify import (
+    verify_store_with_seed,
+    verify_challenge_with_seed,
+    verify_retrieve_with_seed,
+)
+from .database import add_metadata_to_hotkey
+from .bonding import update_statistics, get_tier_factor
+from .event import EventSchema
+
+from storage.protocol import Store, Retrieve, Challenge
 
 
 def adjusted_sigmoid(x, steepness=1, shift=0):
@@ -250,25 +263,12 @@ def apply_reward_scores(
     bt.logging.trace(f"Updated moving avg scores: {self.moving_averaged_scores}")
 
 
-from bittensor import Synapse
-
-from .verify import (
-    verify_store_with_seed,
-    verify_challenge_with_seed,
-    verify_retrieve_with_seed,
-)
-from .database import add_metadata_to_hotkey
-from .bonding import update_statistics, get_tier_factor
-from .event import EventSchema
-from storage.protocol import Store, Retrieve, Challenge
-
-import sys
-from pprint import pformat
+from functools import partial
 
 
 async def create_reward_vector(
     self,
-    synapse: Union[Store, Retrieve],
+    synapse: Union[Store, Retrieve, Challenge],
     rewards: torch.FloatTensor,
     uids: List[int],
     responses: List[Synapse],
@@ -276,21 +276,34 @@ async def create_reward_vector(
     callback: callable,
     fail_callback: callable,
 ):
+    # Determine if the commitment is valid
+    success = False
     if isinstance(synapse, Store):
-        verify_fn = verify_store_with_seed
+        verify_fn = partial(
+            verify_store_with_seed,
+            b64_encrypted_data=synapse.encrypted_data,
+            seed=synapse.seed,
+        )
+        task_type = "store"
     elif isinstance(synapse, Retrieve):
-        verify_fn = verify_retrieve_with_seed
+        verify_fn = partial(verify_retrieve_with_seed, seed=synapse.seed)
+        task_type = "retrieve"
     elif isinstance(synapse, Challenge):
-        verify_fn = verify_challenge_with_seed
+        verify_fn = partial(verify_challenge_with_seed, seed=synapse.seed)
+        task_type = "challenge"
     else:
         raise ValueError(f"Invalid synapse type: {type(synapse)}")
 
     for idx, (uid, response) in enumerate(zip(uids, responses)):
         # Verify the commitment
         hotkey = self.metagraph.hotkeys[uid]
-        success = verify_fn(response)
+
+        # Determine if the commitment is valid
+        success = verify_fn(synapse=response)
         if success:
-            bt.logging.debug(f"Successfully verified store commitment from UID: {uid}")
+            bt.logging.debug(
+                f"Successfully verified {synapse.__class__} commitment from UID: {uid}"
+            )
             await callback(hotkey, idx, uid, response)
         else:
             bt.logging.error(f"Failed to verify store commitment from UID: {uid}")
@@ -300,11 +313,11 @@ async def create_reward_vector(
         await update_statistics(
             ss58_address=hotkey,
             success=success,
-            task_type="store",
+            task_type=task_type,
             database=self.database,
         )
 
-        # Apply reward for this store
+        # Apply reward for this task
         tier_factor = await get_tier_factor(hotkey, self.database)
         rewards[idx] = 1.0 * tier_factor if success else 0.0
 

--- a/storage/validator/store.py
+++ b/storage/validator/store.py
@@ -44,15 +44,8 @@ from storage.validator.utils import (
     make_random_file,
     compute_chunk_distribution_mut_exclusive_numpy_reuse_uids,
 )
-from storage.validator.encryption import (
-    decrypt_data,
-    encrypt_data,
-)
-from storage.validator.verify import (
-    verify_store_with_seed,
-    verify_challenge_with_seed,
-    verify_retrieve_with_seed,
-)
+from storage.validator.encryption import encrypt_data
+from storage.validator.verify import verify_store_with_seed
 from storage.validator.reward import apply_reward_scores
 from storage.validator.database import (
     add_metadata_to_hotkey,

--- a/storage/validator/store.py
+++ b/storage/validator/store.py
@@ -259,7 +259,7 @@ async def store_random_data(self):
 
     # Encrypt the data
     # TODO: create and use a throwaway wallet (never decrypable)
-    encrypted_data, encryption_payload = encrypt_data(data, self.wallet)
+    encrypted_data, encryption_payload = encrypt_data(data, self.encryption_wallet)
 
     return await store_encrypted_data(
         self, encrypted_data, encryption_payload, ttl=self.config.neuron.data_ttl

--- a/storage/validator/verify.py
+++ b/storage/validator/verify.py
@@ -63,7 +63,7 @@ def verify_chained_commitment(proof, seed, commitment, verbose=True):
     return expected_commitment == commitment
 
 
-def verify_challenge_with_seed(synapse, verbose=False):
+def verify_challenge_with_seed(synapse, seed, verbose=False):
     """
     Verifies a challenge in a decentralized network using a seed and the details contained in a synapse.
     The function validates the initial commitment hash against the expected result, checks the integrity of the commitment,
@@ -81,7 +81,7 @@ def verify_challenge_with_seed(synapse, verbose=False):
         return False
 
     if not verify_chained_commitment(
-        synapse.commitment_proof, synapse.seed, synapse.commitment_hash, verbose=verbose
+        synapse.commitment_proof, seed, synapse.commitment_hash, verbose=verbose
     ):
         bt.logging.error(f"Initial commitment hash does not match expected result.")
         bt.logging.error(f"synapse {pformat(synapse.dendrite.dict())}")
@@ -97,13 +97,13 @@ def verify_challenge_with_seed(synapse, verbose=False):
 
     if not committer.open(
         commitment,
-        hash_data(base64.b64decode(synapse.data_chunk) + str(synapse.seed).encode()),
+        hash_data(base64.b64decode(synapse.data_chunk) + str(seed).encode()),
         synapse.randomness,
     ):
         if verbose:
             bt.logging.error(f"Opening commitment failed!")
             bt.logging.error(f"commitment: {synapse.commitment[:100]}")
-            bt.logging.error(f"seed      : {synapse.seed}")
+            bt.logging.error(f"seed      : {seed}")
             bt.logging.error(f"synapse   : {pformat(synapse.dendrite.dict())}")
         return False
 
@@ -123,7 +123,7 @@ def verify_challenge_with_seed(synapse, verbose=False):
     return True
 
 
-def verify_store_with_seed(synapse, verbose=False):
+def verify_store_with_seed(synapse, b64_encrypted_data, seed, verbose=False):
     """
     Verifies the storing process in a decentralized network using the provided synapse and seed.
     This function decodes the data, reconstructs the hash using the seed, and verifies it against the commitment hash.
@@ -134,16 +134,14 @@ def verify_store_with_seed(synapse, verbose=False):
     Returns:
         bool: True if the storing process is verified successfully, False otherwise.
     """
-    # TODO: Add checks and defensive programming here to handle all types
-    # (bytes, str, hex, ecc point, etc)
     try:
-        decoded_data = base64.b64decode(synapse.encrypted_data)
+        encrypted_data = base64.b64decode(b64_encrypted_data)
     except Exception as e:
-        bt.logging.error(f"Could not decode data with error: {e}")
+        bt.logging.error(f"Could not decode store data with error: {e}")
         return False
 
-    seed_value = str(synapse.seed).encode()
-    reconstructed_hash = hash_data(decoded_data + seed_value)
+    seed_value = str(seed).encode()
+    reconstructed_hash = hash_data(encrypted_data + seed_value)
 
     # e.g. send synapse.commitment_hash as an int for consistency
     if synapse.commitment_hash != str(reconstructed_hash):
@@ -162,7 +160,7 @@ def verify_store_with_seed(synapse, verbose=False):
 
     if not committer.open(
         commitment,
-        hash_data(decoded_data + str(synapse.seed).encode()),
+        hash_data(encrypted_data + str(seed).encode()),
         synapse.randomness,
     ):
         bt.logging.error(f"Opening commitment failed")
@@ -172,7 +170,7 @@ def verify_store_with_seed(synapse, verbose=False):
     return True
 
 
-def verify_retrieve_with_seed(synapse, verbose=False):
+def verify_retrieve_with_seed(synapse, seed, verbose=False):
     """
     Verifies the retrieval process in a decentralized network using the provided synapse and seed.
     The function validates the initial commitment hash against the expected result using the provided seed and commitment proof.
@@ -183,13 +181,13 @@ def verify_retrieve_with_seed(synapse, verbose=False):
         bool: True if the retrieval process is verified successfully, False otherwise.
     """
     if not verify_chained_commitment(
-        synapse.commitment_proof, synapse.seed, synapse.commitment_hash, verbose=verbose
+        synapse.commitment_proof, seed, synapse.commitment_hash, verbose=verbose
     ):
         bt.logging.error(f"Initial commitment hash does not match expected result.")
         if verbose:
             bt.logging.error(f"synapse {synapse.dendrite.dict()}")
             bt.logging.error(f"commitment_proof: {synapse.commitment_proof}")
-            bt.logging.error(f"seed            : {synapse.seed}")
+            bt.logging.error(f"seed            : {seed}")
             bt.logging.error(f"commitment_hash : {synapse.commitment_hash}")
         return False
 


### PR DESCRIPTION
**CRITICAL SECURITY UPGRADE**
* Migrate away from using personal coldkey exposure to use a dummy wallet (auto-setup)

Incentive Fixes:
* Fix verification bug with miners no longer returning `store` data.  Use original data + seed to verify miner commitment hash.
* Extend timeout for pinging miners before requests, and specifically in `monitor`
* Update hparams for num challenge UIDs per round, monitor max pings before considered down, etc

General Improvements and Bugfixes:
* Don't whitelist API by default
* Delete unused code & cleanup
* change `vpermit_tao_limit` to 500
* bugfix for validator with no `decoded_data` to retrieve if no UIDs caused validator crash
* Fix some import bugs and typos