### PR TITLE
Temporarily disable negative reward penalty to allow miners to get established

### DIFF
--- a/storage/validator/challenge.py
+++ b/storage/validator/challenge.py
@@ -215,7 +215,7 @@ async def challenge_data(self):
 
         # Apply reward for this challenge
         tier_factor = await get_tier_factor(hotkey, self.database)
-        rewards[idx] = 1.0 * tier_factor if verified else -0.02 * tier_factor
+        rewards[idx] = 1.0 * tier_factor if verified else -0.01 * tier_factor
 
         # Log the event data for this specific challenge
         event.uids.append(uid)

--- a/storage/validator/challenge.py
+++ b/storage/validator/challenge.py
@@ -215,7 +215,7 @@ async def challenge_data(self):
 
         # Apply reward for this challenge
         tier_factor = await get_tier_factor(hotkey, self.database)
-        rewards[idx] = 1.0 * tier_factor if verified else -0.01 * tier_factor
+        rewards[idx] = 1.0 * tier_factor if verified else 0.0
 
         # Log the event data for this specific challenge
         event.uids.append(uid)

--- a/storage/validator/network.py
+++ b/storage/validator/network.py
@@ -207,7 +207,7 @@ async def monitor(self):
                 task_type="monitor",
                 database=self.database,
             )
-            rewards[i] = -0.01
+            rewards[i] = 0.0
 
         scattered_rewards: torch.FloatTensor = self.moving_averaged_scores.scatter(
             0, torch.tensor(down_uids).to(self.device), rewards

--- a/storage/validator/network.py
+++ b/storage/validator/network.py
@@ -207,7 +207,7 @@ async def monitor(self):
                 task_type="monitor",
                 database=self.database,
             )
-            rewards[i] = -0.05
+            rewards[i] = -0.01
 
         scattered_rewards: torch.FloatTensor = self.moving_averaged_scores.scatter(
             0, torch.tensor(down_uids).to(self.device), rewards

--- a/storage/validator/retrieve.py
+++ b/storage/validator/retrieve.py
@@ -178,7 +178,7 @@ async def retrieve_data(
             bt.logging.error(
                 f"Failed to decode data from UID: {uids[idx]} with error {e}"
             )
-            rewards[idx] = -0.1
+            rewards[idx] = -0.02
 
             # Update the retrieve statistics
             await update_statistics(

--- a/storage/validator/retrieve.py
+++ b/storage/validator/retrieve.py
@@ -209,7 +209,7 @@ async def retrieve_data(
             bt.logging.error(
                 f"data verification failed! {pformat(response.axon.dict())}"
             )
-            rewards[idx] = -0.1  # Losing use data is unacceptable, harsh punishment
+            rewards[idx] = 0.0  # Losing use data is unacceptable, harsh punishment
 
             # Update the retrieve statistics
             await update_statistics(


### PR DESCRIPTION
This is a hotfix so that miners are not unfairly deregistered who may have had mishaps in failing to migrate data to new servers and do not experience premature deregistration.

This will be turned back ON when a complete examination has been carried out of which should be negatively rewarded and how much.