### PR TITLE
update to sigmoid reward scaling for latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,7 +729,9 @@ It is *highly* recommended that all miners and validators run their own local su
 
 To start your miner/validator using your local node, include the flag `--subtensor.network local` into your startup parameters.
 
-### Docker installation
+Below are two methods to getting local subtensor up and running. Either use docker, or manually install on the hostmachine.
+
+#### Docker installation
 For easiest installation, run subtensor inside of the foundation-provided docker container.
 
 For official docker and docker-compose install instructions, see [here](https://docs.docker.com/engine/install/ubuntu/#installation-methods) and [here](https://docs.docker.com/compose/install/linux/#install-using-the-repository), respectively.
@@ -747,7 +749,7 @@ cd subtensor
 sudo docker compose up -d
 ```
 
-#### Quick Installation
+#### Manual Installation
 Provided are two scripts to build subtensor, and then to run it inside a pm2 process as a convenience. If you have more complicated needs, see the [subtensor](https://github.com/opentensor/subtensor/) repo for more details and understanding.
 ```bash
 # Installs dependencies and builds the subtensor binary

--- a/storage/validator/challenge.py
+++ b/storage/validator/challenge.py
@@ -255,7 +255,7 @@ async def challenge_data(self):
         responses,
         rewards,
         timeout=self.config.neuron.challenge_timeout,
-        mode="minmax",
+        mode=self.config.neuron.reward_mode,
     )
 
     # Determine the best UID based on rewards

--- a/storage/validator/config.py
+++ b/storage/validator/config.py
@@ -163,6 +163,13 @@ def add_args(cls, parser):
         help="Override random chunk size to split data into for challenges.",
     )
     parser.add_argument(
+        "--neuron.reward_mode",
+        default="sigmoid",
+        type=str,
+        choices=["minmax", "sigmoid"],
+        help="Reward mode for the validator.",
+    )
+    parser.add_argument(
         "--neuron.store_redundancy",
         type=int,
         default=4,

--- a/storage/validator/retrieve.py
+++ b/storage/validator/retrieve.py
@@ -256,7 +256,7 @@ async def retrieve_data(
         [response_tuple[0] for response_tuple in response_tuples],
         rewards,
         timeout=self.config.neuron.retrieve_timeout,
-        mode="minmax",
+        mode=self.config.neuron.reward_mode,
     )
 
     # Determine the best UID based on rewards
@@ -345,7 +345,7 @@ async def retrieve_broadband(self, full_hash: str):
             responses,
             rewards,
             timeout=self.config.neuron.retrieve_timeout,
-            mode="minmax",
+            mode=self.config.neuron.reward_mode,
         )
 
         # Determine the best UID based on rewards

--- a/storage/validator/store.py
+++ b/storage/validator/store.py
@@ -193,7 +193,7 @@ async def store_encrypted_data(
             responses,
             rewards,
             timeout=self.config.neuron.store_timeout,
-            mode="minmax",
+            mode=self.config.neuron.reward_mode,
         )
 
         # Get a new set of UIDs to query for those left behind
@@ -373,7 +373,7 @@ async def store_broadband(
             responses,
             rewards,
             timeout=self.config.neuron.store_timeout,
-            mode="minmax",
+            mode=self.config.neuron.reward_mode,
         )
 
         bt.logging.debug(f"Updated reward scores: {rewards.tolist()}")


### PR DESCRIPTION
Provide a more graceful latency rewards curve. This incentivizes a majority of the responses to be within 50% of the timeout window. Full timeouts incur 0 reward.

![image](https://github.com/ifrit98/storage-subnet/assets/31426574/34ca05ea-9457-4353-874f-a99f9d6bfd1b)


This also allows the reintroduction of negative rewards (follow-up PR)