### PR TITLE
start the sub handler thread in run()

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -22,12 +22,14 @@ import base64
 import typing
 import asyncio
 import aioredis
+import threading
 import traceback
 import bittensor as bt
-
+from copy import deepcopy
 from loguru import logger
 from pprint import pformat
 from traceback import print_exception
+from substrateinterface.base import SubstrateInterface
 
 from storage import protocol
 from storage.validator.utils import get_current_validtor_uid_round_robin
@@ -173,11 +175,6 @@ class neuron:
         # Init the event loop.
         self.loop = asyncio.get_event_loop()
 
-        # Start the subscription handler
-        bt.logging.debug(f"starting event handler")
-        self.start_neuron_event_subscription()
-        bt.logging.debug(f"started event handler")
-
         # Init wandb.
         if not self.config.wandb.off:
             bt.logging.debug("loading wandb")
@@ -193,41 +190,12 @@ class neuron:
         # TODO: load this from disk instead of reset on restart
         self.monitor_lookup = {uid: 0 for uid in self.metagraph.uids.tolist()}
 
-    async def neuron_registered_subscription_handler(
-        self, obj, update_nr, subscription_id
-    ):
-        bt.logging.debug(f"New block #{obj['header']['number']}")
-        self.current_block = obj["header"]["number"]
-
-        bt.logging.debug(obj)
-
-        block_no = obj["header"]["number"]
-        block_hash = self.subtensor.get_block_hash(block_no)
-        bt.logging.debug(f"subscription block hash: {block_hash}")
-        events = self.subtensor.substrate.get_events(block_hash)
-        for event in events:
-            event_dict = event["event"].decode()
-            if event_dict["event_id"] == "NeuronRegistered":
-                netuid, uid, hotkey = event_dict["attributes"]
-                if int(netuid) == 21:
-                    bt.logging.info(
-                        f"NeuronRegistered Event {uid}! Rebalancing data..."
-                    )
-                    with open(self.config.neuron.debug_logging_path, "a") as file:
-                        file.write(
-                            f"NeuronRegistered Event {uid}! Rebalancing data..."
-                            f"{pformat(event_dict)}\n"
-                        )
-                    await rebalance_data(
-                        self, k=2, dropped_hotkeys=[hotkey], hotkey_replaced=True
-                    )
-
-    def start_neuron_event_subscription(self):
-        asyncio.run(
-            self.subtensor.substrate.subscribe_block_headers(
-                self.neuron_registered_subscription_handler
-            )
-        )
+        # Instantiate runners
+        self.should_exit: bool = False
+        self.subscription_is_running: bool = False
+        self.subscription_thread: threading.Thread = None
+        self.last_registered_block = 0
+        self.rebalance_queue = []
 
     def run(self):
         bt.logging.info("run()")
@@ -236,13 +204,16 @@ class neuron:
             bt.logging.info("purging challenges")
 
             async def run_purge():
-                await asyncio.gather([purge_challenges_for_all_hotkeys(self.database)])
+                await asyncio.gather(purge_challenges_for_all_hotkeys(self.database))
 
             self.loop.run_until_complete(run_purge())
             bt.logging.info("purged challenges.")
 
         load_state(self)
         checkpoint(self)
+
+        bt.logging.info("starting subscription handler")
+        self.run_subscription_thread()
 
         try:
             while True:
@@ -310,6 +281,91 @@ class neuron:
                     "KeyboardInterrupt caught, gracefully closing the wandb run..."
                 )
                 self.wandb.finish()
+
+    def log(self, log: str):
+        bt.logging.debug(log)
+
+        with open(self.config.neuron.subscription_logging_path, "a") as file:
+            file.write(log)
+
+    def start_event_subscription(self):
+        """
+        Starts the subscription handler in a background thread.
+        """
+        substrate = SubstrateInterface(
+            ss58_format=bt.__ss58_format__,
+            use_remote_preset=True,
+            url=self.subtensor.chain_endpoint,
+            type_registry=bt.__type_registry__,
+        )
+
+        def neuron_registered_subscription_handler(
+            obj, update_nr, subscription_id
+        ):
+            self.log(f"New block #: {obj['header']['number']}\n")
+            bt.logging.debug(obj)
+
+            block_no = obj["header"]["number"]
+            block_hash = substrate.get_block_hash(block_id=block_no)
+            bt.logging.debug(f"subscription block hash: {block_hash}")
+            events = substrate.get_events(block_hash)
+
+            self.log(f"Events: {pformat(events)}\n")
+
+            for event in events:
+                event_dict = event["event"].decode()
+                if event_dict["event_id"] == "NeuronRegistered":
+                    netuid, uid, hotkey = event_dict["attributes"]
+                    if int(netuid) == 21:
+                        self.log(
+                            f"NeuronRegistered Event {uid}! Rebalancing data...\n"
+                            f"{pformat(event_dict)}\n"
+                        )
+
+                        self.last_registered_block = block_no
+                        self.rebalance_queue.append(hotkey)
+
+            # If we have some hotkeys deregistered, and it's been 5 blocks since we've caught a registration: rebalance
+            if len(self.rebalance_queue) > 0 and self.last_registered_block + 5 <= block_no:
+                hotkeys = deepcopy(self.rebalance_queue)
+                self.rebalance_queue.clear()
+
+                self.loop.run_until_complete(
+                    rebalance_data(self, k=2, dropped_hotkeys=hotkeys, hotkey_replaced=True)
+                )
+
+        substrate.subscribe_block_headers(
+            neuron_registered_subscription_handler
+        )
+
+    def run_subscription_thread(self):
+        """
+        Start the block header subscription handler in a separate thread.
+        """
+        if not self.subscription_is_running:
+            self.subscription_thread = threading.Thread(
+                target=self.start_event_subscription, daemon=True
+            )
+            self.subscription_thread.start()
+            self.subscription_is_running = True
+            bt.logging.debug("Started subscription handler.")
+
+    def stop_subscription_thread(self):
+        """
+        Stops the subscription handler that is running in the background thread.
+        """
+        if self.subscription_is_running:
+            bt.logging.debug("Stopping subscription in background thread.")
+            self.should_exit = True
+            self.subscription_thread.join(5)
+            self.subscription_is_running = False
+            bt.logging.debug("Stopped")
+
+    def __del__(self):
+        """
+        Stops the subscription handler thread.
+        """
+        self.stop_subscription_thread()
 
 
 def main():

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -310,8 +310,6 @@ class neuron:
             bt.logging.debug(f"subscription block hash: {block_hash}")
             events = substrate.get_events(block_hash)
 
-            self.log(f"Events: {pformat(events)}\n")
-
             for event in events:
                 event_dict = event["event"].decode()
                 if event_dict["event_id"] == "NeuronRegistered":
@@ -330,6 +328,7 @@ class neuron:
                 hotkeys = deepcopy(self.rebalance_queue)
                 self.rebalance_queue.clear()
 
+                bt.logging.debug(f"Running rebalance in background on hotkeys {hotkeys}")
                 self.loop.run_until_complete(
                     rebalance_data(self, k=2, dropped_hotkeys=hotkeys, hotkey_replaced=True)
                 )

--- a/storage/validator/config.py
+++ b/storage/validator/config.py
@@ -236,6 +236,12 @@ def add_args(cls, parser):
         default=False,
     )
     parser.add_argument(
+        "--neuron.subscription_logging_path",
+        type=str,
+        help="The path to save subscription logs.",
+        default="subscription_logs.txt",
+    )
+    parser.add_argument(
         "--neuron.chunk_factor",
         type=int,
         help="The chunk factor to divide data.",

--- a/storage/validator/database.py
+++ b/storage/validator/database.py
@@ -882,7 +882,7 @@ async def purge_challenges_for_hotkey(ss58_address: str, database: aioredis.Redi
     challenge_hashes = await get_challenges_for_hotkey(ss58_address, database)
     bt.logging.trace(f"purging challenges for {ss58_address}...")
     for ch in challenge_hashes:
-        await database.delete(ch)
+        await database.hdel(f"hotkey:{ss58_address}", ch)
 
 
 async def purge_challenges_for_all_hotkeys(database: aioredis.Redis):


### PR DESCRIPTION
This updates the subscription handler to run in a separate thread instead of relying on the `asyncio` task scheduler to correctly do it's job. Adds a queue for monitoring replaced hotkeys and batch processing them.