### PR TITLE
widen latency reward spread

### DIFF
--- a/storage/validator/reward.py
+++ b/storage/validator/reward.py
@@ -74,9 +74,9 @@ def calculate_sigmoid_params(timeout):
     Returns:
     - tuple: A tuple containing the 'steepness' and 'shift' values for the current timeout.
     """
-    base_timeout = 1  # 10
-    base_steepness = 10  # 1
-    base_shift = 0.3  # 4
+    base_timeout = 1
+    base_steepness = 7
+    base_shift = 0.5
 
     # Calculate the ratio of the current timeout to the base timeout
     ratio = timeout / base_timeout

--- a/storage/validator/reward.py
+++ b/storage/validator/reward.py
@@ -75,8 +75,8 @@ def calculate_sigmoid_params(timeout):
     - tuple: A tuple containing the 'steepness' and 'shift' values for the current timeout.
     """
     base_timeout = 1
-    base_steepness = 7
-    base_shift = 0.5
+    base_steepness = 5
+    base_shift = 0.6
 
     # Calculate the ratio of the current timeout to the base timeout
     ratio = timeout / base_timeout


### PR DESCRIPTION
Widens the spread between reward response times, facilitating a fairer reward spread.

* Adjust base shift: `0.3` -> `0.6`
* Adjust base steepness `10` -> `6`

Before:
<img width="693" alt="image" src="https://github.com/ifrit98/storage-subnet/assets/31426574/9dd0f865-906e-4023-8d6d-9a97fc896c03">


After:
<img width="693" alt="image" src="https://github.com/ifrit98/storage-subnet/assets/31426574/332f1bf4-7a95-413e-945f-f48ab70691f9">

