### PR TITLE
Hotfix/validator subscrition handler

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -360,13 +360,13 @@ class neuron:
             ):
                 hotkeys = deepcopy(self.rebalance_queue)
                 self.rebalance_queue.clear()
+                self.log(f"Running rebalance in separate process on hotkeys {hotkeys}")
 
-                self.log(f"Running rebalance in background on hotkeys {hotkeys}")
-                self.loop.run_until_complete(
-                    rebalance_data(
-                        self, k=2, dropped_hotkeys=hotkeys, hotkey_replaced=True
-                    )
-                )
+                # Fire off the script
+                hotkeys_str = ','.join(map(str, hotkeys))
+                hotkeys_arg = quote(hotkeys_str)
+                path = os.path.join(os.path.abspath("."), "scripts/rebalance_deregistration.sh")
+                subprocess.run([path, hotkeys_arg])
 
         substrate.subscribe_block_headers(neuron_registered_subscription_handler)
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -368,7 +368,7 @@ class neuron:
                 path = os.path.join(
                     os.path.abspath("."), "scripts/rebalance_deregistration.sh"
                 )
-                subprocess.run(
+                subprocess.Popen(
                     [
                         path,
                         hotkeys_arg,

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -363,10 +363,19 @@ class neuron:
                 self.log(f"Running rebalance in separate process on hotkeys {hotkeys}")
 
                 # Fire off the script
-                hotkeys_str = ','.join(map(str, hotkeys))
+                hotkeys_str = ",".join(map(str, hotkeys))
                 hotkeys_arg = quote(hotkeys_str)
-                path = os.path.join(os.path.abspath("."), "scripts/rebalance_deregistration.sh")
-                subprocess.run([path, hotkeys_arg])
+                path = os.path.join(
+                    os.path.abspath("."), "scripts/rebalance_deregistration.sh"
+                )
+                subprocess.run(
+                    [
+                        path,
+                        hotkeys_arg,
+                        self.subtensor.chain_endpoint,
+                        str(self.config.database.index),
+                    ]
+                )
 
         substrate.subscribe_block_headers(neuron_registered_subscription_handler)
 

--- a/scripts/rebalance_deregistration.py
+++ b/scripts/rebalance_deregistration.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+import os
+import asyncio
+import aioredis
+import argparse
+import bittensor as bt
+
+from storage.validator.rebalance import rebalance_data
+
+
+async def main(args):
+    try:
+        subtensor = bt.subtensor(network=args.network)
+        metagraph = bt.metagraph(netuid=args.netuid, network=args.network)
+        metagraph.sync(subtensor=subtensor)
+        database = aioredis.StrictRedis(db=args.database_index)
+
+        hotkeys = args.hotkeys.split(",")
+        bt.logging.info(f"Deregistered hotkeys {hotkeys} will be rebalanced in the index.")
+
+        self = argparse.Namespace()
+        self.metagraph = metagraph
+        self.database = database
+
+        await rebalance_data(
+            self, k=2, dropped_hotkeys=hotkeys, hotkey_replaced=True
+        )
+
+    finally:
+        if "subtensor" in locals():
+            subtensor.close()
+            bt.logging.debug("closing subtensor connection")
+
+
+
+if __name__ == "__main__":
+    try:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--hotkeys", type=str, required=True, help="comma separated list of hotkeys to deregister")
+        parser.add_argument("--network", type=str, default="local")
+        parser.add_argument("--netuid", type=int, default=21)
+        parser.add_argument("--database_index", type=int, default=1)
+        args = parser.parse_args()
+
+        asyncio.run(main(args))
+    except KeyboardInterrupt:
+        print("KeyboardInterrupt")
+    except ValueError as e:
+        print(f"ValueError: {e}")

--- a/scripts/rebalance_deregistration.py
+++ b/scripts/rebalance_deregistration.py
@@ -17,15 +17,15 @@ async def main(args):
         database = aioredis.StrictRedis(db=args.database_index)
 
         hotkeys = args.hotkeys.split(",")
-        bt.logging.info(f"Deregistered hotkeys {hotkeys} will be rebalanced in the index.")
+        bt.logging.info(
+            f"Deregistered hotkeys {hotkeys} will be rebalanced in the index."
+        )
 
         self = argparse.Namespace()
         self.metagraph = metagraph
         self.database = database
 
-        await rebalance_data(
-            self, k=2, dropped_hotkeys=hotkeys, hotkey_replaced=True
-        )
+        await rebalance_data(self, k=2, dropped_hotkeys=hotkeys, hotkey_replaced=True)
 
     finally:
         if "subtensor" in locals():
@@ -33,11 +33,15 @@ async def main(args):
             bt.logging.debug("closing subtensor connection")
 
 
-
 if __name__ == "__main__":
     try:
         parser = argparse.ArgumentParser()
-        parser.add_argument("--hotkeys", type=str, required=True, help="comma separated list of hotkeys to deregister")
+        parser.add_argument(
+            "--hotkeys",
+            type=str,
+            required=True,
+            help="comma separated list of hotkeys to deregister",
+        )
         parser.add_argument("--network", type=str, default="local")
         parser.add_argument("--netuid", type=int, default=21)
         parser.add_argument("--database_index", type=int, default=1)

--- a/scripts/rebalance_deregistration.sh
+++ b/scripts/rebalance_deregistration.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python scripts/rebalance_deregistration.py --hotkeys "$1"
+python scripts/rebalance_deregistration.py --hotkeys "$1" --network "$2" --database_index "$3"

--- a/scripts/rebalance_deregistration.sh
+++ b/scripts/rebalance_deregistration.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python scripts/rebalance_deregistration.py --hotkeys "$1"


### PR DESCRIPTION
Don't block the main thread with subscription handler. (Fixes `Context already entered` error).

Runs `rebalance_data` upon `NeuonRegistration` event (deregistered neurons) in a separate process to unblock main.