### PR TITLE
Run neurons using the CLI

### DIFF
--- a/docs/redis/migrate-to-new-server.md
+++ b/docs/redis/migrate-to-new-server.md
@@ -4,11 +4,13 @@ In the *origin* server we have to create a dump of the database. We can do it as
 ```bash
 # server: origin
 A$ redis-cli
+127.0.0.1:6379> auth <your-passwd>
 127.0.0.1:6379> CONFIG GET dir
 1) "dir"
 2) "/var/lib/redis/"
 127.0.0.1:6379> SAVE
 OK
+A$ scp /var/lib/redis/dump.rdb user@destiny-ip:/tmp/dump.rdb
 ```
 
 In the *destiny* server we have to incorporate that data. We can do it as follows:

--- a/neurons/api.py
+++ b/neurons/api.py
@@ -455,9 +455,9 @@ class neuron:
         self.stop_run_thread()
 
 
-def main():
+def run_api():
     neuron().run()
 
 
 if __name__ == "__main__":
-    main()
+    run_api()

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -969,7 +969,7 @@ class miner:
         self.stop_run_thread()
 
 
-def main():
+def run_miner():
     """
     Main function to run the neuron.
 
@@ -992,4 +992,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    run_miner()

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -415,9 +415,9 @@ class neuron:
             self.stop_subscription_thread()
 
 
-def main():
+def run_validator():
     neuron().run()
 
 
 if __name__ == "__main__":
-    main()
+    run_validator()

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,0 @@
-pytest==7.4.3
-pytest-cov==4.1.0
-parameterized==0.9.0

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,11 @@ setup(
     author_email="ifrit98@gmail.com",
     license="MIT",
     python_requires=">=3.9,<3.11",
-    scripts=["bin/ftcli"],
+    entry_points={
+        "console_scripts": [
+            "filetao=storage.cli.cli:filetao"
+        ]
+    },
     install_requires=requirements,
     extras_require={"dev": extra_requirements_dev},
     classifiers=[

--- a/storage/cli/cli.py
+++ b/storage/cli/cli.py
@@ -217,3 +217,8 @@ class cli:
         else:
             print(f":cross_mark:[red]Unknown command: {self.config.command}[/red]")
             sys.exit()
+
+
+def filetao():
+    args = sys.argv[1:]
+    cli(args=args).run()

--- a/storage/cli/cli.py
+++ b/storage/cli/cli.py
@@ -27,6 +27,7 @@ from .retrievecommand import RetrieveData
 from .storecommand import StoreData
 from .listcommand import ListLocalHashes
 from .statscommand import ListMinerStats
+from .neuroncommand import RunMiner, RunValidator, RunApi
 
 # Create a console instance for CLI display.
 console = bittensor.__console__
@@ -38,9 +39,11 @@ ALIAS_TO_COMMAND = {
     "s": "store",
     "r": "retrieve",
     "m": "miner",
+    "n": "run",
     "retrieve": "retrieve",
     "store": "store",
     "miner": "miner",
+    "run": "run",
 }
 
 COMMANDS = {
@@ -67,6 +70,16 @@ COMMANDS = {
         "help": "Commands for retrieving statistics from the Bittensor network.",
         "commands": {
             "stats": ListMinerStats,  # lists all miner stats associated with hotkey
+        },
+    },
+    "run": {
+        "name": "run",
+        "aliases": ["n", "run"],
+        "help": "Commands for running neurons in this subnetwork.",
+        "commands": {
+            "miner": RunMiner,
+            "validator": RunValidator,
+            "api": RunApi,
         },
     },
 }

--- a/storage/cli/neuroncommand.py
+++ b/storage/cli/neuroncommand.py
@@ -17,6 +17,8 @@
 # DEALINGS IN THE SOFTWARE.
 
 from argparse import ArgumentParser
+from bittensor import config as bt_config
+
 from neurons.miner import run_miner
 from neurons.validator import run_validator
 from neurons.api import run_api
@@ -30,7 +32,7 @@ class RunApi:
         run_api()
     
     @staticmethod
-    def check_config(config: "bittensor.config"):
+    def check_config(config: "bt_config"):
         pass
 
     @staticmethod
@@ -46,7 +48,7 @@ class RunMiner:
         run_miner()
     
     @staticmethod
-    def check_config(config: "bittensor.config"):
+    def check_config(config: "bt_config"):
         pass
 
     @staticmethod
@@ -62,7 +64,7 @@ class RunValidator:
         run_validator()
     
     @staticmethod
-    def check_config(config: "bittensor.config"):
+    def check_config(config: "bt_config"):
         pass
 
     @staticmethod

--- a/storage/cli/neuroncommand.py
+++ b/storage/cli/neuroncommand.py
@@ -1,0 +1,70 @@
+# The MIT License (MIT)
+# Copyright © 2023 Yuma Rao
+# Copyright © 2023 philanthrope
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+from argparse import ArgumentParser
+from neurons.miner import run_miner
+from neurons.validator import run_validator
+from neurons.api import run_api
+
+
+class RunApi:
+
+    @staticmethod
+    def run(cli):
+        r"""Run api neuron"""
+        run_api()
+    
+    @staticmethod
+    def check_config(config: "bittensor.config"):
+        pass
+
+    @staticmethod
+    def add_args(parser: ArgumentParser):
+        parser.add_parser("api", help="""Run api neuron""")
+
+
+class RunMiner:
+
+    @staticmethod
+    def run(cli):
+        r"""Run miner neuron"""
+        run_miner()
+    
+    @staticmethod
+    def check_config(config: "bittensor.config"):
+        pass
+
+    @staticmethod
+    def add_args(parser: ArgumentParser):
+        parser.add_parser("miner", help="""Run miner neuron""")
+
+
+class RunValidator:
+
+    @staticmethod
+    def run(cli):
+        r"""Run validator neuron"""
+        run_validator()
+    
+    @staticmethod
+    def check_config(config: "bittensor.config"):
+        pass
+
+    @staticmethod
+    def add_args(parser: ArgumentParser):
+        parser.add_parser("validator", help="""Run validator neuron""")


### PR DESCRIPTION
- using setup.py `entry_points` instead of `scripts`
- naming the cli `filetao` instead of `ftcli`
- run neurons using cli
  - `filetao run miner`
  - `filetao run validator`
  - `filetao run api`
- boyscouting
  - updating redis doc for migration
  - removing unused `requirements.dev.txt` (it was previously renamed to requirements-dev.txt)