### PR TITLE
Dockerize filetao

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,13 @@ name: Python package
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
   pull_request:
-    branches: [ "main", "staging", "release/.*" ]
+    branches:
+      - main
+      - staging
+      - release/*
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ celerybeat.pid
 
 # Environments
 .env
+**/*.env
 .venv
 env/
 venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+ARG BASE_IMAGE=python:3.10.12-slim
+FROM $BASE_IMAGE AS builder-prod
+
+# This is being set so that no interactive components are allowed when updating.
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Create directory to copy files to
+RUN mkdir /install/
+WORKDIR /install
+
+# Copy our sources
+COPY ./neurons /install/neurons
+COPY ./storage /install/storage
+COPY ./setup.py /install/setup.py
+COPY ./requirements.txt /install/requirements.txt
+COPY ./requirements-dev.txt /install/requirements-dev.txt
+COPY ./README.md /install/README.md
+
+RUN python -m pip install --prefix=/install .
+
+#
+# Stage for running filetao on productive servers
+#
+FROM $BASE_IMAGE AS filetao-prod
+
+ARG NEURON_TYPE=miner
+ARG WANDB_API_KEY
+
+COPY --from=builder-prod /install/bin/ /usr/local/bin
+COPY --from=builder-prod /install/lib/ /usr/local/lib
+
+RUN mkdir -p ~/.bittensor/wallets && \
+    mkdir -p /etc/redis/
+
+ENV PATH="${PATH}:/usr/local/bin:/usr/local/lib"
+ENV WANDB_API_KEY=$WANDB_API_KEY
+
+#RUN wandb login

--- a/Dockerfile.redis
+++ b/Dockerfile.redis
@@ -1,0 +1,15 @@
+FROM redis:7.2.4-alpine
+
+ARG REDIS_CONF
+ENV REDIS_CONF=$REDIS_CONF
+
+RUN mkdir /etc/redis/ && \
+    mkdir /var/lib/redis/  && \
+    mkdir /var/run/redis/
+
+COPY $REDIS_CONF /etc/redis/
+RUN mv /etc/redis/*.conf /etc/redis/redis.conf
+
+RUN chown -R redis:redis /etc/redis/ && \
+    chown -R redis:redis /var/lib/redis/ && \
+    chown redis:redis /var/run/redis

--- a/config/redis-docker.conf
+++ b/config/redis-docker.conf
@@ -1,0 +1,152 @@
+# Redis configuration file example.
+#
+# Note that in order to read the configuration file, Redis must be
+# started with the file path as first argument:
+#
+# ./redis-server /path/to/redis.conf
+
+bind 0.0.0.0
+
+protected-mode yes
+
+port 6379
+
+requirepass CHANGEME4321
+
+tcp-backlog 511
+
+timeout 0
+
+tcp-keepalive 300
+
+daemonize no
+
+supervised auto
+
+pidfile /run/redis/redis-server.pid
+
+loglevel notice
+
+databases 16
+
+always-show-logo no
+
+set-proc-title yes
+
+proc-title-template "{title} {listen-addr} {server-mode}"
+
+locale-collate ""
+
+#
+#save 900 1
+#save 300 10
+#save 60 10000
+#
+# Snapshotting can be completely disabled with a single empty string argument
+# as in following example:
+#
+save ""
+
+stop-writes-on-bgsave-error yes
+
+rdbcompression yes
+rdbchecksum yes
+
+# The filename where to dump the DB
+dbfilename dump.rdb
+
+rdb-del-sync-files no
+
+dir /var/lib/redis
+
+replica-serve-stale-data yes
+
+replica-read-only yes
+repl-diskless-sync yes
+repl-diskless-sync-delay 5
+repl-diskless-sync-max-replicas 0
+
+repl-diskless-load disabled
+repl-disable-tcp-nodelay no
+
+replica-priority 100
+
+acllog-max-len 128
+
+lazyfree-lazy-eviction no
+lazyfree-lazy-expire no
+lazyfree-lazy-server-del no
+replica-lazy-flush no
+
+lazyfree-lazy-user-del no
+
+lazyfree-lazy-user-flush no
+
+oom-score-adj no
+oom-score-adj-values 0 200 800
+
+disable-thp yes
+
+appendonly yes
+
+appendfilename "appendonly.aof"
+appenddirname "appendonlydir"
+
+# appendfsync always
+appendfsync everysec
+# appendfsync no
+
+no-appendfsync-on-rewrite no
+
+auto-aof-rewrite-percentage 100
+auto-aof-rewrite-min-size 64mb
+
+aof-load-truncated yes
+
+aof-use-rdb-preamble yes
+
+aof-timestamp-enabled no
+
+slowlog-log-slower-than 10000
+
+slowlog-max-len 128
+
+latency-monitor-threshold 0
+
+notify-keyspace-events ""
+
+hash-max-listpack-entries 512
+hash-max-listpack-value 64
+
+list-max-listpack-size -2
+
+list-compress-depth 0
+
+set-max-intset-entries 512
+
+set-max-listpack-entries 128
+set-max-listpack-value 64
+
+zset-max-listpack-entries 128
+zset-max-listpack-value 64
+
+hll-sparse-max-bytes 3000
+
+stream-node-max-bytes 4096
+stream-node-max-entries 100
+
+activerehashing yes
+
+client-output-buffer-limit normal 0 0 0
+client-output-buffer-limit replica 256mb 64mb 60
+client-output-buffer-limit pubsub 32mb 8mb 60
+
+hz 10
+
+dynamic-hz yes
+
+aof-rewrite-incremental-fsync yes
+
+rdb-save-incremental-fsync yes
+
+jemalloc-bg-thread yes

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,7 +46,7 @@ services:
       - ${BT_WALLETS_BASE_PATH}/.bittensor/wallets:/root/.bittensor/wallets
       - .:/install
       - ${REDIS_CONF}:/etc/redis/redis.conf
-      - ${FILETAO_MINER_DATA_DIR}:~/.data/
+      - ${FILETAO_MINER_DATA_DIR}:/root/.data/
 
   filetao-validator-prod:
     <<: *filetao-prod

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,7 @@ services:
           --axon.external_port ${FILETAO_EXTERNAL_PORT} \
           --subtensor.network ${FILETAO_SUBTENSOR} \
           --database.host localhost \
+          --database.port ${REDIS_PORT} \
           --database.redis_password ${REDIS_PASSWORD} \
           ${FILETAO_EXTRA_OPTIONS}
 
@@ -69,6 +70,7 @@ services:
           --axon.external_port ${FILETAO_API_EXTERNAL_PORT} \
           --subtensor.network ${FILETAO_SUBTENSOR} \
           --database.host localhost \
+          --database.port ${REDIS_PORT} \
           --database.redis_password ${REDIS_PASSWORD} \
           ${FILETAO_EXTRA_OPTIONS}
 
@@ -89,6 +91,6 @@ services:
       - redis-server
       - /etc/redis/redis.conf
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT}:${REDIS_PORT}"
     volumes:
       - redis-prod-data:/var/lib/redis

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,6 +43,9 @@ services:
     <<: *filetao-prod
     container_name: filetao-miner-prod
     volumes:
+      - ${BT_WALLETS_BASE_PATH}/.bittensor/wallets:/root/.bittensor/wallets
+      - .:/install
+      - ${REDIS_CONF}:/etc/redis/redis.conf
       - ${FILETAO_MINER_DATA_DIR}:~/.data/
 
   filetao-validator-prod:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
           --wallet.name ${FILETAO_WALLET}  \
           --wallet.hotkey ${FILETAO_HOTKEY} \
           --netuid ${FILETAO_NETUID} \
-          --axon.ip ${FILETAO_EXTERNAL_PORT} \
+          --axon.external_port ${FILETAO_EXTERNAL_PORT} \
           --subtensor.network ${FILETAO_SUBTENSOR} \
           --database.host localhost \
           --database.redis_password ${REDIS_PASSWORD} \
@@ -55,8 +55,6 @@ services:
   filetao-api-prod:
     <<: *filetao-prod
     container_name: filetao-api-prod
-    ports:
-      - "${FILETAO_API_EXTERNAL_PORT}:${FILETAO_API_EXTERNAL_PORT}"
     command:
       - /bin/bash
       - -c
@@ -65,7 +63,7 @@ services:
           --wallet.name ${FILETAO_WALLET}  \
           --wallet.hotkey ${FILETAO_HOTKEY} \
           --netuid ${FILETAO_NETUID} \
-          --axon.ip ${FILETAO_API_EXTERNAL_PORT} \
+          --axon.external_port ${FILETAO_API_EXTERNAL_PORT} \
           --subtensor.network ${FILETAO_SUBTENSOR} \
           --database.host localhost \
           --database.redis_password ${REDIS_PASSWORD} \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,6 +32,7 @@ services:
           --wallet.name ${FILETAO_WALLET}  \
           --wallet.hotkey ${FILETAO_HOTKEY} \
           --netuid ${FILETAO_NETUID} \
+          --axon.port ${FILETAO_EXTERNAL_PORT} \
           --axon.external_port ${FILETAO_EXTERNAL_PORT} \
           --subtensor.network ${FILETAO_SUBTENSOR} \
           --database.host localhost \
@@ -59,6 +60,7 @@ services:
           --wallet.name ${FILETAO_WALLET}  \
           --wallet.hotkey ${FILETAO_HOTKEY} \
           --netuid ${FILETAO_NETUID} \
+          --axon.port ${FILETAO_EXTERNAL_PORT} \
           --axon.external_port ${FILETAO_API_EXTERNAL_PORT} \
           --subtensor.network ${FILETAO_SUBTENSOR} \
           --database.host localhost \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -88,6 +88,6 @@ services:
       - redis-server
       - /etc/redis/redis.conf
     expose:
-      - "6379"
+      - "6379:6379"
     volumes:
       - redis-prod-data:/var/lib/redis

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,10 +11,6 @@ services:
       context: .
       dockerfile: Dockerfile
     restart: always
-    ports:
-      - "${FILETAO_EXTERNAL_PORT}:${FILETAO_EXTERNAL_PORT}"
-    expose:
-      - "${FILETAO_EXTERNAL_PORT}"
     depends_on:
       redis:
         condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -81,7 +81,7 @@ services:
     container_name: filetao-redis
     restart: always
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli -a ${REDIS_PASSWORD} ping | grep PONG"]
+      test: ["CMD-SHELL", "redis-cli -a ${REDIS_PASSWORD} -p ${REDIS_PORT} ping | grep PONG"]
       interval: 1s
       timeout: 3s
       retries: 5
@@ -89,6 +89,6 @@ services:
       - redis-server
       - /etc/redis/redis.conf
     ports:
-      - "${REDIS_PORT}:${REDIS_PORT}"
+      - "${REDIS_PORT}:6379"
     volumes:
       - redis-prod-data:/var/lib/redis

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,8 +15,6 @@ services:
       - "${FILETAO_EXTERNAL_PORT}:${FILETAO_EXTERNAL_PORT}"
     expose:
       - "${FILETAO_EXTERNAL_PORT}"
-    links:
-      - redis
     depends_on:
       redis:
         condition: service_healthy
@@ -29,6 +27,7 @@ services:
     <<: *common
     build:
       target: filetao-prod
+    network_mode: host
     command:
       - /bin/bash
       - -c
@@ -39,7 +38,7 @@ services:
           --netuid ${FILETAO_NETUID} \
           --axon.ip ${FILETAO_EXTERNAL_PORT} \
           --subtensor.network ${FILETAO_SUBTENSOR} \
-          --database.host redis \
+          --database.host localhost \
           --database.redis_password ${REDIS_PASSWORD} \
           ${FILETAO_EXTRA_OPTIONS}
 
@@ -68,7 +67,7 @@ services:
           --netuid ${FILETAO_NETUID} \
           --axon.ip ${FILETAO_API_EXTERNAL_PORT} \
           --subtensor.network ${FILETAO_SUBTENSOR} \
-          --database.host redis \
+          --database.host localhost \
           --database.redis_password ${REDIS_PASSWORD} \
           ${FILETAO_EXTRA_OPTIONS}
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,92 @@
+version: '3.8'
+
+volumes:
+  redis-prod-data:
+    name: "filetao-redis-data"
+
+services:
+  common: &common
+    #image: noimageyet
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: always
+    ports:
+      - "${FILETAO_EXTERNAL_PORT}:8091"
+    expose:
+      - "8091"
+    links:
+      - redis
+    depends_on:
+      redis:
+        condition: service_healthy
+    volumes:
+      - ${BT_WALLETS_BASE_PATH}/.bittensor/wallets:/root/.bittensor/wallets
+      - .:/install
+      - ${REDIS_CONF}:/etc/redis/redis.conf
+
+  filetao-prod: &filetao-prod
+    <<: *common
+    build:
+      target: filetao-prod
+    command:
+      - /bin/bash
+      - -c
+      - |
+        filetao run ${FILETAO_NODE} \
+          --wallet.name ${FILETAO_WALLET}  \
+          --wallet.hotkey ${FILETAO_HOTKEY} \
+          --netuid ${FILETAO_NETUID} \
+          --subtensor.network ${FILETAO_SUBTENSOR} \
+          --database.host redis \
+          --database.redis_password ${REDIS_PASSWORD} \
+          ${FILETAO_EXTRA_OPTIONS}
+
+  filetao-miner-prod:
+    <<: *filetao-prod
+    container_name: filetao-miner-prod
+
+  filetao-validator-prod:
+    <<: *filetao-prod
+    container_name: filetao-validator-prod
+    depends_on:
+      - filetao-api-prod
+
+  filetao-api-prod:
+    <<: *filetao-prod
+    container_name: filetao-api-prod
+    ports:
+      - "${FILETAO_API_EXTERNAL_PORT}:8091"
+    command:
+      - /bin/bash
+      - -c
+      - |
+        filetao run api \
+          --wallet.name ${FILETAO_WALLET}  \
+          --wallet.hotkey ${FILETAO_HOTKEY} \
+          --netuid ${FILETAO_NETUID} \
+          --subtensor.network ${FILETAO_SUBTENSOR} \
+          --database.host redis \
+          --database.redis_password ${REDIS_PASSWORD} \
+          ${FILETAO_EXTRA_OPTIONS}
+
+  redis:
+    build:
+      context: .
+      args:
+        REDIS_CONF: ${REDIS_CONF}
+      dockerfile: Dockerfile.redis
+    container_name: filetao-redis
+    restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a ${REDIS_PASSWORD} ping | grep PONG"]
+      interval: 1s
+      timeout: 3s
+      retries: 5
+    command:
+      - redis-server
+      - /etc/redis/redis.conf
+    expose:
+      - "6379"
+    volumes:
+      - redis-prod-data:/var/lib/redis

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,6 +42,8 @@ services:
   filetao-miner-prod:
     <<: *filetao-prod
     container_name: filetao-miner-prod
+    volumes:
+      - ${FILETAO_MINER_DATA_DIR}:~/.data/
 
   filetao-validator-prod:
     <<: *filetao-prod

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,6 @@ services:
         condition: service_healthy
     volumes:
       - ${BT_WALLETS_BASE_PATH}/.bittensor/wallets:/root/.bittensor/wallets
-      - .:/install
       - ${REDIS_CONF}:/etc/redis/redis.conf
 
   filetao-prod: &filetao-prod
@@ -45,7 +44,6 @@ services:
     container_name: filetao-miner-prod
     volumes:
       - ${BT_WALLETS_BASE_PATH}/.bittensor/wallets:/root/.bittensor/wallets
-      - .:/install
       - ${REDIS_CONF}:/etc/redis/redis.conf
       - ${FILETAO_MINER_DATA_DIR}:/root/.data/
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -81,7 +81,7 @@ services:
     container_name: filetao-redis
     restart: always
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli -a ${REDIS_PASSWORD} -p ${REDIS_PORT} ping | grep PONG"]
+      test: ["CMD-SHELL", "redis-cli -a ${REDIS_PASSWORD} ping | grep PONG"]
       interval: 1s
       timeout: 3s
       retries: 5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,9 +12,9 @@ services:
       dockerfile: Dockerfile
     restart: always
     ports:
-      - "${FILETAO_EXTERNAL_PORT}:8091"
+      - "${FILETAO_EXTERNAL_PORT}:${FILETAO_EXTERNAL_PORT}"
     expose:
-      - "8091"
+      - "${FILETAO_EXTERNAL_PORT}"
     links:
       - redis
     depends_on:
@@ -37,6 +37,7 @@ services:
           --wallet.name ${FILETAO_WALLET}  \
           --wallet.hotkey ${FILETAO_HOTKEY} \
           --netuid ${FILETAO_NETUID} \
+          --axon.ip ${FILETAO_EXTERNAL_PORT} \
           --subtensor.network ${FILETAO_SUBTENSOR} \
           --database.host redis \
           --database.redis_password ${REDIS_PASSWORD} \
@@ -56,7 +57,7 @@ services:
     <<: *filetao-prod
     container_name: filetao-api-prod
     ports:
-      - "${FILETAO_API_EXTERNAL_PORT}:8091"
+      - "${FILETAO_API_EXTERNAL_PORT}:${FILETAO_API_EXTERNAL_PORT}"
     command:
       - /bin/bash
       - -c
@@ -65,6 +66,7 @@ services:
           --wallet.name ${FILETAO_WALLET}  \
           --wallet.hotkey ${FILETAO_HOTKEY} \
           --netuid ${FILETAO_NETUID} \
+          --axon.ip ${FILETAO_API_EXTERNAL_PORT} \
           --subtensor.network ${FILETAO_SUBTENSOR} \
           --database.host redis \
           --database.redis_password ${REDIS_PASSWORD} \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -87,7 +87,7 @@ services:
     command:
       - redis-server
       - /etc/redis/redis.conf
-    expose:
+    ports:
       - "6379:6379"
     volumes:
       - redis-prod-data:/var/lib/redis

--- a/docs/docker/run-filetao-with-docker.md
+++ b/docs/docker/run-filetao-with-docker.md
@@ -10,6 +10,8 @@
     - `FILETAO_NETUID`: Net UID of the bittensor subnet to connect.
     - `FILETAO_SUBTENSOR`: Subtensor network to connect.
     - `FILETAO_EXTERNAL_PORT`: Port to be used externally (in the host) by the neuron's container.
+    - `FILETAO_API_EXTERNAL_PORT`: Port to be used externally (in the host) by the api neuron's container
+    - `FILETAO_MINER_DATA_DIR`: Host data directory to be mapped to the neuron's container (used in the miner neuron)
     - `FILETAO_EXTRA_OPTIONS`: Extra options to be added, not specified in the rest of the ENVVARs, like `--wandb.off` or `--logging.debug`.
 - Since some of env vars could be shared between containers, if you run validator or miner or the api in the same host, we recommend you to have 2 environment files:
     - common.env

--- a/docs/docker/run-filetao-with-docker.md
+++ b/docs/docker/run-filetao-with-docker.md
@@ -1,0 +1,22 @@
+# Run filetao with docker
+
+- To run the defined docker compose services {filetao-miner-prod, filetao-validator-prod, redis} you will need the followings environment variables:
+    - `BT_WALLETS_BASE_PATH`: The base path of your bittensor wallets. Typically equivalent to `$HOME`.
+    - `REDIS_PASSWORD`: Your redis instance password.
+    - `REDIS_CONF`: Your redis conf path. If you use the base one provided in this repository it could be `./config/redis-docker.conf`.
+    - `FILETAO_NODE`: Type of node you want to run. To be miner, validator or api.
+    - `FILETAO_WALLET`: Bittensor wallet name to use.
+    - `FILETAO_HOTKEY`: Bittensor hotkey name to use.
+    - `FILETAO_NETUID`: Net UID of the bittensor subnet to connect.
+    - `FILETAO_SUBTENSOR`: Subtensor network to connect.
+    - `FILETAO_EXTERNAL_PORT`: Port to be used externally (in the host) by the neuron's container.
+    - `FILETAO_EXTRA_OPTIONS`: Extra options to be added, not specified in the rest of the ENVVARs, like `--wandb.off` or `--logging.debug`.
+- Since some of env vars could be shared between containers, if you run validator or miner or the api in the same host, we recommend you to have 2 environment files:
+    - common.env
+    - filetao-(miner|validator|api)-prod.env
+- Once you have the needed env files, you can run the docker compose containers defined. If you have followed the suggested steps, you can use the following commands:
+    - Running miner: `sudo docker compose --env-file common.env --env-file filetao-miner.env up --build filetao-miner-prod`
+    - Running validator: `sudo docker compose --env-file common.env --env-file filetao-validator.env up --build filetao-validator-prod`
+    - Running api: `sudo docker compose --env-file common.env --env-file filetao-api.env up --build filetao-api-prod`
+
+> If you just use one env file you would need just one --env-file option :)

--- a/docs/docker/run-filetao-with-docker.md
+++ b/docs/docker/run-filetao-with-docker.md
@@ -3,6 +3,7 @@
 - To run the defined docker compose services {filetao-miner-prod, filetao-validator-prod, redis} you will need the followings environment variables:
     - `BT_WALLETS_BASE_PATH`: The base path of your bittensor wallets. Typically equivalent to `$HOME`.
     - `REDIS_PASSWORD`: Your redis instance password.
+    - `REDIS_PORT`: Port to run redis within a docker container (same port is exposed)
     - `REDIS_CONF`: Your redis conf path. If you use the base one provided in this repository it could be `./config/redis-docker.conf`.
     - `FILETAO_NODE`: Type of node you want to run. To be miner, validator or api.
     - `FILETAO_WALLET`: Bittensor wallet name to use.

--- a/docs/docker/use-redis-database-from-localhost.md
+++ b/docs/docker/use-redis-database-from-localhost.md
@@ -1,0 +1,43 @@
+# Use Redis Database from localhost
+
+This process is similar to [migrate redis to new server](../redis/migrate-to-new-server.md). But in this case it all happens within the same host machine.
+
+## Creating, run and stop redis container once
+
+**Assuming**, that this is the first time you are going to run the redis container.
+
+We will start by the redis container.
+
+- First, we are going to build the container:
+    - `sudo docker compose --env-file common.env --env-file filetao-validator.env up --build redis -d`
+- Then, we are going to stop it:
+    - `sudo docker compose --env-file common.env --env-file filetao-validator.env down redis`
+
+### Why have we done this?
+We have created, run and stop the container to force the creation of the volume and have locally what we have in the redis container aswell (we expect to see just the `appendonlydir` directory).
+
+## Creating Redis local backup and move it to the Redis container
+
+In this section, we **assume** that you have the default docker setup and you are using `/var/lib/docker` as your docker root directory. If this is not the case, ensure you use the corresponding command, with the correct docker root directory.
+
+In the *host* server we have to create a dump of the database. We can do it as follows:
+```bash
+# server: origin
+A$ redis-cli
+127.0.0.1:6379> auth <your-passwd>
+127.0.0.1:6379> CONFIG GET dir
+1) "dir"
+2) "/var/lib/redis/"
+127.0.0.1:6379> SAVE
+OK
+A$ mv /var/lib/redis/dump.rdb /var/lib/docker/volumes/filetao-redis-data/_data/
+```
+
+In the *destiny* server we have to incorporate that data. We can do it as follows:
+```bash
+# server: origin
+sudo docker compose --env-file common.env --env-file filetao-validator.env down redis
+sudo docker compose --env-file common.env --env-file filetao-validator.env up --build redis -d
+```
+
+Now the redis container will receive the backup that we have just created and it is supposed to automatically get the new data.

--- a/neurons/api.py
+++ b/neurons/api.py
@@ -84,6 +84,7 @@ class neuron:
             asyncio.run(check_environment(
                 self.config.database.redis_conf_path,
                 self.config.database.host,
+                self.config.database.port,
                 redis_password
             ))
         except AssertionError as e:

--- a/neurons/api.py
+++ b/neurons/api.py
@@ -79,8 +79,13 @@ class neuron:
         bt.logging(config=self.config, logging_dir=self.config.neuron.full_path)
         print(self.config)
 
+        redis_password = get_redis_password(self.config.database.redis_password)
         try:
-            asyncio.run(check_environment(self.config.database.redis_conf_path))
+            asyncio.run(check_environment(
+                self.config.database.redis_conf_path,
+                self.config.database.host,
+                redis_password
+            ))
         except AssertionError as e:
             bt.logging.warning(
                 f"Something is missing in your environment: {e}. Please check your configuration, use the README for help, and try again."
@@ -136,7 +141,6 @@ class neuron:
 
         # Setup database
         bt.logging.info("loading database")
-        redis_password = get_redis_password(self.config.database.redis_password)
         self.database = aioredis.StrictRedis(
             host=self.config.database.host,
             port=self.config.database.port,
@@ -155,7 +159,7 @@ class neuron:
         self.my_subnet_uid = self.metagraph.hotkeys.index(
             self.wallet.hotkey.ss58_address
         )
-        bt.logging.info(f"Running validator on uid: {self.my_subnet_uid}")
+        bt.logging.info(f"Running validator (api) on uid: {self.my_subnet_uid}")
 
         bt.logging.debug("serving ip to chain...")
         try:

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -130,8 +130,13 @@ class miner:
         bt.logging(config=self.config, logging_dir=self.config.miner.full_path)
         bt.logging.info(f"{self.config}")
 
+        redis_password = get_redis_password(self.config.database.redis_password)
         try:
-            asyncio.run(check_environment(self.config.database.redis_conf_path))
+            asyncio.run(check_environment(
+                self.config.database.redis_conf_path,
+                self.config.database.host,
+                redis_password
+            ))
         except AssertionError as e:
             bt.logging.warning(
                 f"Something is missing in your environment: {e}. Please check your configuration, use the README for help, and try again."
@@ -174,7 +179,6 @@ class miner:
 
         # Setup database
         bt.logging.info("loading database")
-        redis_password = get_redis_password(self.config.database.redis_password)
         self.database = aioredis.StrictRedis(
             host=self.config.database.host,
             port=self.config.database.port,

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -135,6 +135,7 @@ class miner:
             asyncio.run(check_environment(
                 self.config.database.redis_conf_path,
                 self.config.database.host,
+                self.config.database.port,
                 redis_password
             ))
         except AssertionError as e:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -96,8 +96,13 @@ class neuron:
         bt.logging(config=self.config, logging_dir=self.config.neuron.full_path)
         print(self.config)
 
+        redis_password = get_redis_password(self.config.database.redis_password)
         try:
-            asyncio.run(check_environment(self.config.database.redis_conf_path))
+            asyncio.run(check_environment(
+                self.config.database.redis_conf_path,
+                self.config.database.host,
+                redis_password
+            ))
         except AssertionError as e:
             bt.logging.warning(
                 f"Something is missing in your environment: {e}. Please check your configuration, use the README for help, and try again."
@@ -156,7 +161,6 @@ class neuron:
 
         # Setup database
         bt.logging.info("loading database")
-        redis_password = get_redis_password(self.config.database.redis_password)
         self.database = aioredis.StrictRedis(
             host=self.config.database.host,
             port=self.config.database.port,

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -101,6 +101,7 @@ class neuron:
             asyncio.run(check_environment(
                 self.config.database.redis_conf_path,
                 self.config.database.host,
+                self.config.database.port,
                 redis_password
             ))
         except AssertionError as e:

--- a/scripts/migrate_redis_index.py
+++ b/scripts/migrate_redis_index.py
@@ -14,8 +14,14 @@ async def main(args):
     if not os.path.exists(new_directory):
         os.makedirs(new_directory, exist_ok=True)
 
+    redis_password = get_redis_password(args.redis_password)
     try:
-        asyncio.run(check_environment(args.redis_conf_path))
+        asyncio.run(check_environment(
+            args.redis_conf_path,
+            args.database_host,
+            args.database_port,
+            redis_password
+        ))
     except AssertionError as e:
         bt.logging.warning(
             f"Something is missing in your environment: {e}. Please check your configuration, use the README for help, and try again."
@@ -25,7 +31,6 @@ async def main(args):
     bt.logging.info(
         f"Loading database from {args.database_host}:{args.database_port}"
     )
-    redis_password = get_redis_password(args.redis_password)
     database = aioredis.StrictRedis(
         host=args.database_host,
         port=args.database_port,

--- a/scripts/rebalance_deregistration.py
+++ b/scripts/rebalance_deregistration.py
@@ -12,8 +12,14 @@ from storage.validator.rebalance import rebalance_data
 
 async def main(args):
 
+    redis_password = get_redis_password(args.redis_password)
     try:
-        asyncio.run(check_environment(args.redis_conf_path))
+        asyncio.run(check_environment(
+            args.redis_conf_path,
+            args.database_host,
+            args.database_port,
+            redis_password
+        ))
     except AssertionError as e:
         bt.logging.warning(
             f"Something is missing in your environment: {e}. Please check your configuration, use the README for help, and try again."
@@ -31,7 +37,6 @@ async def main(args):
         bt.logging.info(
             f"Loading database from {args.database_host}:{args.database_port}"
         )
-        redis_password = get_redis_password(args.redis_password)
         database = aioredis.StrictRedis(
             host=args.database_host,
             port=args.database_port,

--- a/scripts/redis/schema_migration/01_migrate.py
+++ b/scripts/redis/schema_migration/01_migrate.py
@@ -12,8 +12,14 @@ from storage.miner.database import convert_all_to_hotkey_format
 
 async def main(args):
 
+    redis_password = get_redis_password(args.redis_password)
     try:
-        asyncio.run(check_environment(args.redis_conf_path))
+        asyncio.run(check_environment(
+            args.redis_conf_path,
+            args.database_host,
+            args.database_port,
+            redis_password
+        ))
     except AssertionError as e:
         bt.logging.warning(
             f"Something is missing in your environment: {e}. Please check your configuration, use the README for help, and try again."
@@ -21,7 +27,6 @@ async def main(args):
 
     try:
         bt.logging.info(f"Loading database from {args.database_host}:{args.database_port}")
-        redis_password = get_redis_password(args.redis_password)
         database = aioredis.StrictRedis(
             host=args.database_host,
             port=args.database_port,

--- a/scripts/redis/schema_migration/02_clean.py
+++ b/scripts/redis/schema_migration/02_clean.py
@@ -12,8 +12,14 @@ from storage.miner.database import safe_remove_all_old_keys
 
 async def main(args):
 
+    redis_password = get_redis_password(args.redis_password)
     try:
-        asyncio.run(check_environment(args.redis_conf_path))
+        asyncio.run(check_environment(
+            args.redis_conf_path,
+            args.database_host,
+            args.database_port,
+            redis_password
+        ))
     except AssertionError as e:
         bt.logging.warning(
             f"Something is missing in your environment: {e}. Please check your configuration, use the README for help, and try again."
@@ -21,7 +27,6 @@ async def main(args):
 
     try:
         bt.logging.info(f"Loading database from {args.database_host}:{args.database_port}")
-        redis_password = get_redis_password(args.redis_password)
         database = aioredis.StrictRedis(
             host=args.database_host,
             port=args.database_port,

--- a/storage/cli/cli.py
+++ b/storage/cli/cli.py
@@ -73,15 +73,15 @@ COMMANDS = {
         },
     },
     "run": {
-         "name": "run",
-         "aliases": ["n", "run"],
-         "help": "Commands for running neurons in this subnetwork.",
-         "commands": {
-             "miner": RunMiner,
-             "validator": RunValidator,
-             "api": RunApi,
-         },
-     },
+        "name": "run",
+        "aliases": ["n", "run"],
+        "help": "Commands for running neurons in this subnetwork.",
+        "commands": {
+            "miner": RunMiner,
+            "validator": RunValidator,
+            "api": RunApi,
+        },
+    },
 }
 
 

--- a/storage/shared/checks.py
+++ b/storage/shared/checks.py
@@ -5,19 +5,23 @@ import re
 import os
 from redis import asyncio as aioredis
 
+from storage.shared.utils import is_running_in_docker
 
-async def check_environment(redis_conf_path: str = "/etc/redis/redis.conf"):
+
+async def check_environment(redis_conf_path: str = "/etc/redis/redis.conf", redis_host: str = "localhost", redis_password: str = "nopasswd"):
     redis_port = 6379
     _check_redis_config(redis_conf_path)
     _check_redis_settings(redis_conf_path)
     _assert_setting_exists(redis_conf_path, "requirepass")
-    await _check_redis_connection(redis_conf_path, redis_port)
-    await _check_data_persistence(redis_conf_path, redis_port)
+    await _check_redis_connection(redis_conf_path, redis_host, redis_port, redis_password)
+    if not is_running_in_docker:
+        await _check_data_persistence(redis_conf_path, redis_host, redis_port, redis_password)
 
 
 def _check_redis_config(path):
+    cmd = ["test", "-f", path] if is_running_in_docker() else ["sudo", "test", "-f", path]
     try:
-        subprocess.run(["sudo", "test", "-f", path], check=True)
+        subprocess.run(cmd, check=True)
     except subprocess.CalledProcessError:
         raise AssertionError(f"Redis config file path: '{path}' does not exist.")
 
@@ -32,37 +36,38 @@ def _check_redis_settings(redis_conf_path):
         _check_redis_setting(redis_conf_path, setting, expected_values)
 
 
-async def _check_redis_connection(redis_conf_path, port):
-    redis_password = _get_redis_password(redis_conf_path)
-
+async def _check_redis_connection(redis_conf_path, host, port, passwd):
     assert port is not None, "Redis server port not found"
     try:
         client = aioredis.StrictRedis(
-            port=port, db=0, password=redis_password, socket_connect_timeout=1
+            host=host,
+            port=port, db=0,
+            password=passwd, socket_connect_timeout=1
         )
         await client.ping()
     except Exception as e:
         assert False, f"Redis connection failed. ConnectionError'{e}'"
 
 
-async def _check_data_persistence(redis_conf_path, port):
-    redis_password = _get_redis_password(redis_conf_path)
-
+async def _check_data_persistence(redis_conf_path, host, port, passwd):
     assert port is not None, "Redis server port not found"
-    client = aioredis.StrictRedis(port=port, db=0, password=redis_password)
+    client = aioredis.StrictRedis(host=host, port=port, db=0, password=passwd)
 
     # Insert data into Redis
     await client.set("testkey", "Hello, Redis!")
 
     # Restart Redis server
-    subprocess.run(["sudo", "systemctl", "restart", "redis-server.service"], check=True)
+    cmd = ["systemctl", "restart", "redis-server.service"] if is_running_in_docker() else [
+        "sudo", "systemctl", "restart", "redis-server.service"
+    ]
+    subprocess.run(cmd, check=True)
 
     # Wait a bit to ensure Redis has restarted
     await asyncio.sleep(5)
 
     # Reconnect to Redis
     assert port is not None, "Redis server port not found after restart"
-    new_redis = aioredis.StrictRedis(port=port, db=0, password=redis_password)
+    new_redis = aioredis.StrictRedis(port=port, db=0, password=passwd)
 
     # Retrieve data from Redis
     value = await new_redis.get("testkey")
@@ -95,25 +100,13 @@ def _assert_setting_exists(file_path, setting):
 
 def _get_redis_setting(file_path, setting):
     """Retrieve specific settings from the Redis configuration file."""
+    cmd = ["grep", f"^{setting}", file_path] if is_running_in_docker() else [
+        "sudo", "grep", f"^{setting}", file_path
+    ]
     try:
         result = subprocess.check_output(
-            ["sudo", "grep", f"^{setting}", file_path], text=True
+            cmd, text=True
         )
         return result.strip().split("\n")
     except subprocess.CalledProcessError:
         return None
-
-
-def _get_redis_password(redis_conf_path):
-    try:
-        cmd = f"sudo grep -Po '^requirepass \K.*' {redis_conf_path}"
-        result = subprocess.run(
-            cmd, shell=True, text=True, capture_output=True, check=True
-        )
-        return result.stdout.strip()
-    except subprocess.CalledProcessError as e:
-        assert False, f"Command failed: {e}"
-    except Exception as e:
-        assert False, f"An error occurred: {e}"
-
-    return None

--- a/storage/shared/checks.py
+++ b/storage/shared/checks.py
@@ -8,8 +8,12 @@ from redis import asyncio as aioredis
 from storage.shared.utils import is_running_in_docker
 
 
-async def check_environment(redis_conf_path: str = "/etc/redis/redis.conf", redis_host: str = "localhost", redis_password: str = "nopasswd"):
-    redis_port = 6379
+async def check_environment(
+    redis_conf_path: str = "/etc/redis/redis.conf",
+    redis_host: str = "localhost",
+    redis_port: int = 6379,
+    redis_password: str = "nopasswd"
+):
     _check_redis_config(redis_conf_path)
     _check_redis_settings(redis_conf_path)
     _assert_setting_exists(redis_conf_path, "requirepass")

--- a/storage/shared/utils.py
+++ b/storage/shared/utils.py
@@ -26,6 +26,16 @@ from typing import List, Union
 from redis import asyncio as aioredis
 
 
+def is_running_in_docker():
+    if os.path.exists('/.dockerenv'):
+        return True
+    try:
+        with open('/proc/self/cgroup', 'rt') as f:
+            return any('docker' in line or 'kubepods' in line for line in f)
+    except Exception:
+        return False
+
+
 async def safe_key_search(database: aioredis.Redis, pattern: str) -> List[str]:
     """
     Safely search for keys in the database that doesn't block.
@@ -136,8 +146,9 @@ def get_redis_password(
     redis_password = os.getenv("REDIS_PASSWORD") or redis_password
     if redis_password is None:
         try:
+            cmd = ["grep", "-Po", "^requirepass \K.*", redis_conf] if is_running_in_docker() else ["sudo", "grep", "-Po", "^requirepass \K.*", redis_conf]
             redis_password = subprocess.check_output(
-                ["sudo", "grep", "-Po", "^requirepass \K.*", redis_conf],
+                cmd,
                 text=True,
             ).strip()
         except Exception as e:


### PR DESCRIPTION
- Dockerizing filetao
  - Dockerfile for filetao
  - Specific Dockerfile.redis for redis
  - Docker compose to run:
    - filetao-miner
    - filetao-validator
    - filetao-api
    - redis
  - it will run redis along with any other filetao container
- Adding docs
  - [running  filetao with docker](https://github.com/ifrit98/storage-subnet/pull/150/files#diff-aadc4c568b0f9df66afe57e9739ac8b0761413f886ff86131e0542f9a9301b64)
  - [using redis database from localhost](https://github.com/ifrit98/storage-subnet/pull/150/files#diff-dd4aa2a20950494056930effe8e6e699bd41185f8022bebef0dd4d5627bde41d)
- Fixing testing [github action](https://github.com/ifrit98/storage-subnet/pull/150/files#diff-ee49282f461b4c8ad179f79dd5bcdf93124561074c64a771366caf93e99b9320) to be run in PRs mergin to release/* branches
- Updating usage of `check_environment` in neurons code