### PR TITLE
Add json event logger and plotting utils

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -48,6 +48,7 @@ from storage.validator.state import (
     load_state,
     save_state,
     init_wandb,
+    log_event,
 )
 from storage.validator.weights import (
     set_weights_for_validator,
@@ -280,7 +281,7 @@ class neuron:
                 )
                 if validator_should_set_weights:
                     bt.logging.debug(f"Setting weights {self.moving_averaged_scores}")
-                    set_weights_for_validator(
+                    event = set_weights_for_validator(
                         subtensor=self.subtensor,
                         wallet=self.wallet,
                         metagraph=self.metagraph,
@@ -290,6 +291,9 @@ class neuron:
                     )
                     prev_set_weights_block = get_current_block(self.subtensor)
                     save_state(self)
+
+                    if event is not None:
+                        log_event(self, event)
 
                 # Rollover wandb to a new run.
                 if should_reinit_wandb(self):

--- a/requirements.plot.txt
+++ b/requirements.plot.txt
@@ -1,0 +1,5 @@
+matplotlib
+plotly
+seaborn
+numpy
+pandas

--- a/scripts/plot_events.py
+++ b/scripts/plot_events.py
@@ -1,3 +1,5 @@
+import argparse
+
 from storage.plot.utils import (
     load_event_dataframe,
     preprocess_data_for_plotting,

--- a/scripts/plot_events.py
+++ b/scripts/plot_events.py
@@ -1,0 +1,36 @@
+from storage.plot.utils import (
+    load_event_dataframe,
+    preprocess_data_for_plotting,
+    preprocess_moving_avg_scores,
+    plot_3d_scatter_data,
+    plot_3d_scatter_data_interactive,
+    plot_3d_scatter_data_interactive_grouped,
+    plot_heatmap_ma_scores,
+    plot_scatter_data,
+)
+
+
+if __name__ == "__main__":
+
+    args = argparse.ArgumentParser()
+    args.add_argument("--filepath", type=str, help="Path to the events log file")
+    args = args.parse_args()
+
+    df = load_event_dataframe(args.filepath)
+    df_rewards = preprocess_data_for_plotting(df, 'rewards')
+    df_completion_times = preprocess_data_for_plotting(df, 'completion_times')
+    df_moving_averaged_scores = preprocess_moving_avg_scores(df, 'moving_averaged_scores')
+
+    plot_scatter_data(df_rewards, 'rewards', 'Rewards Over Time by UID')
+    plot_scatter_data(df_completion_times, 'completion_times', 'Completion Times Over Time by UID')
+
+    plot_3d_scatter_data(df_rewards, 'rewards', '3D Scatter of Rewards Over Time by UID')
+    plot_3d_scatter_data(df_completion_times, 'completion_times', '3D Scatter of Completion Times Over Time by UID')
+
+    plot_3d_scatter_data_interactive(df_rewards, 'rewards', 'Interactive 3D Scatter of Rewards Over Time by UID')
+    plot_3d_scatter_data_interactive(df_completion_times, 'completion_times', 'Interactive 3D Scatter of Completion Times Over Time by UID')
+
+    plot_heatmap_ma_scores(df_moving_averaged_scores)
+
+    plot_3d_scatter_data_interactive_grouped(df_rewards, 'rewards', 'Rewards over time by Task')
+    plot_3d_scatter_data_interactive_grouped(df_completion_times, 'completion_times', 'Completion times over time by Task')

--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -59,6 +59,7 @@ __spec_version__ = version.to_spec_version()
 from . import protocol
 from . import validator
 from . import miner
+from . import plot
 from . import cli
 from .api.store import StoreUserAPI
 from .api.retrieve import RetrieveUserAPI

--- a/storage/plot/utils.py
+++ b/storage/plot/utils.py
@@ -83,6 +83,7 @@ def plot_scatter_data(df, y_column, title):
     ax.set_title(title)
     ax.legend(markerscale=2)
     plt.savefig(f"{y_column}_over_time_scatter.png")
+    print(f"Scatter plot saved as {y_column}_over_time_scatter.png")
 
 def plot_3d_scatter_data(df, y_column, title):
     """Plot specified column over blocks as a 3D scatter plot, with UIDs on another axis."""
@@ -107,6 +108,7 @@ def plot_3d_scatter_data(df, y_column, title):
     ax.set_yticklabels(list(uid_to_y.keys()))
     ax.legend()
     plt.savefig(f"{y_column}_over_time_3D.png")
+    print("3D scatter plot saved as", f"{y_column}_over_time_3D.png")
 
 def plot_3d_scatter_data_interactive(df, y_column, title):
     """Generate an interactive 3D scatter plot of the specified column over blocks."""
@@ -186,3 +188,4 @@ def plot_heatmap_ma_scores(df):
     plt.xlabel('Block Index')
     plt.ylabel('UID')
     plt.savefig("moving_averaged_scores_heatmap.png")
+    print("Heatmap of moving averaged scores saved as moving_averaged_scores_heatmap.png")

--- a/storage/plot/utils.py
+++ b/storage/plot/utils.py
@@ -1,0 +1,188 @@
+import os
+import numpy as np
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+import plotly.graph_objects as go
+from mpl_toolkits.mplot3d import Axes3D
+
+def read_events_into_dataframe(filepath="events_log.json"):
+    """Read the events log into a Pandas DataFrame."""
+    df = pd.read_json(filepath, lines=True)
+    df.set_index('block', inplace=True)
+
+    return df
+
+def load_event_dataframe(filepath=None):
+    """Load the events log into a DataFrame."""
+    if filepath is None:
+        filepath = os.path.join(
+            os.path.expanduser("~/.bittensor/miners/default/validator/netuid21/core_storage_validator/"),
+            "events.json"
+        )
+        if not os.path.exists(filepath):
+            raise FileNotFoundError(f"Events log not found at {filepath}")
+
+    df = read_events_into_dataframe(filepath)
+
+    return df
+
+def get_avg_completion_times(events):
+    """Get the average completion times for each task."""
+    averages = {}
+    for (name, row) in events.groupby('task_name'):
+        print(name, end=': ')
+        times = row['completion_times'].map(lambda x: sum([_ for _ in x if isinstance(_, float)]) / len(x))
+        averages[name] = times.mean()
+        print(averages[name])
+
+    return averages
+
+def preprocess_data_for_plotting(df, column_name):
+    """Expand list columns in the DataFrame for plotting."""
+    rows = []
+    for block, row in df.iterrows():
+        for i in range(len(row[column_name])):
+            new_row = row.to_dict()
+            new_row[column_name] = new_row[column_name][i]
+            if 'uids' in new_row:
+                new_row['uid'] = new_row['uids'][i]
+            new_row['block'] = block
+            rows.append(new_row)
+    new_df = pd.DataFrame(rows)
+    new_df.set_index('block', inplace=True)
+
+    return new_df
+
+def preprocess_moving_avg_scores(df, column_name="moving_averaged_scores"):
+    rows = []
+    for block, row in df.iterrows():
+        if row[column_name] is None: continue
+        for i in range(len(row[column_name])):
+            new_row=row.to_dict()
+            new_row['block'] = block
+        rows.append(new_row)
+    new_df = pd.DataFrame(rows)
+    new_df.set_index("block", inplace=True)
+
+    return new_df
+
+def plot_scatter_data(df, y_column, title):
+    """Plot specified column over blocks as a scatter plot, grouped by UID."""
+    fig, ax = plt.subplots(figsize=(10, 6))
+
+    unique_uids = df['uid'].unique()
+    colors = plt.cm.jet(np.linspace(0, 1, len(unique_uids)))
+
+    for uid, color in zip(unique_uids, colors):
+        subset = df[df['uid'] == uid]
+        ax.scatter(subset.index, subset[y_column], label=f'UID {uid}', s=10, color=color)
+
+    ax.set_xlabel('Block')
+    ax.set_ylabel(y_column)
+    ax.set_title(title)
+    ax.legend(markerscale=2)
+    plt.savefig(f"{y_column}_over_time_scatter.png")
+
+def plot_3d_scatter_data(df, y_column, title):
+    """Plot specified column over blocks as a 3D scatter plot, with UIDs on another axis."""
+    fig = plt.figure(figsize=(10, 7))
+    ax = fig.add_subplot(111, projection='3d')
+
+    unique_uids = df['uid'].unique()
+    colors = plt.cm.jet(np.linspace(0, 1, len(unique_uids)))
+
+    uid_to_y = {uid: i for i, uid in enumerate(unique_uids)}
+
+    for uid, color in zip(unique_uids, colors):
+        subset = df[df['uid'] == uid]
+        ys = np.full(len(subset), uid_to_y[uid])
+        ax.scatter(subset.index, ys, subset[y_column], label=f'UID {uid}', color=color)
+
+    ax.set_xlabel('Block')
+    ax.set_ylabel('UID')
+    ax.set_zlabel(y_column)
+    ax.set_title(title)
+    ax.set_yticks(list(uid_to_y.values()))
+    ax.set_yticklabels(list(uid_to_y.keys()))
+    ax.legend()
+    plt.savefig(f"{y_column}_over_time_3D.png")
+
+def plot_3d_scatter_data_interactive(df, y_column, title):
+    """Generate an interactive 3D scatter plot of the specified column over blocks."""
+    unique_uids = df['uid'].unique()
+    colors = plt.cm.jet(np.linspace(0, 1, len(unique_uids)))
+
+    fig = go.Figure()
+
+    uid_to_y = {uid: i for i, uid in enumerate(unique_uids)}
+
+    for uid, color in zip(unique_uids, colors):
+        subset = df[df['uid'] == uid]
+        color_hex = f'#{int(color[0]*255):02x}{int(color[1]*255):02x}{int(color[2]*255):02x}'
+        fig.add_trace(go.Scatter3d(
+            x=subset.index, 
+            y=[uid_to_y[uid]]*len(subset), 
+            z=subset[y_column],
+            mode='markers',
+            marker=dict(size=5, color=color_hex),
+            name=f'UID {uid}'
+        ))
+
+    fig.update_layout(
+        title=title,
+        scene=dict(
+            xaxis_title='Block',
+            yaxis_title='UID',
+            zaxis_title=y_column
+        ),
+        legend_title="UIDs"
+    )
+    fig.show()
+
+def plot_3d_scatter_data_interactive_grouped(df, y_column, title_prefix):
+    """Generate interactive 3D scatter plots for each task_name group."""
+    grouped = df.groupby('task_name')
+
+    for task_name, group in grouped:
+        unique_uids = group['uid'].unique()
+        # Generate a color map to ensure each UID has a distinct color
+        colors = plt.cm.jet(np.linspace(0, 1, len(unique_uids)))
+
+        fig = go.Figure()
+
+        # Create a numerical index for UIDs to plot on y-axis
+        uid_to_y = {uid: i for i, uid in enumerate(unique_uids)}
+
+        for uid, color in zip(unique_uids, colors):
+            subset = group[group['uid'] == uid]
+            # Convert color from RGBA to hex
+            color_hex = f'#{int(color[0]*255):02x}{int(color[1]*255):02x}{int(color[2]*255):02x}'
+            fig.add_trace(go.Scatter3d(
+                x=subset.index, 
+                y=[uid_to_y[uid]]*len(subset), 
+                z=subset[y_column],
+                mode='markers',
+                marker=dict(size=5, color=color_hex),
+                name=f'UID {uid}'
+            ))
+
+        fig.update_layout(
+            title=f'{title_prefix} - {task_name}',
+            scene=dict(
+                xaxis_title='Block',
+                yaxis_title='UID',
+                zaxis_title=y_column
+            ),
+            legend_title="UIDs"
+        )
+        fig.show()
+
+def plot_heatmap_ma_scores(df):
+    expanded_scores = pd.DataFrame(df['moving_averaged_scores'].tolist(), index=df.index)
+    plt.figure(figsize=(20, 20))
+    sns.heatmap(expanded_scores.T, cmap='viridis')
+    plt.title('Moving Averaged Scores over Time')
+    plt.xlabel('Block Index')
+    plt.ylabel('UID')
+    plt.savefig("moving_averaged_scores_heatmap.png")

--- a/storage/validator/config.py
+++ b/storage/validator/config.py
@@ -109,6 +109,9 @@ def check_config(cls, config: "bt.Config"):
         config.neuron.total_storage_path = os.path.expanduser(
             os.path.join(config.neuron.full_path + "/" + "total_storage.csv")
         )
+        config.neuron.events_json_log_path = os.path.expanduser(
+            os.path.join(config.neuron.full_path + "/" + "events.json")
+        )
 
     bt.logging.info(f"Loaded config in fullpath: {config.neuron.full_path}")
 

--- a/storage/validator/state.py
+++ b/storage/validator/state.py
@@ -20,6 +20,7 @@
 import torch
 import wandb
 import copy
+import json
 
 from loguru import logger
 from dataclasses import asdict
@@ -204,8 +205,16 @@ def log_event(self, event):
     # Log event
     if not self.config.neuron.dont_save_events:
         logger.log("EVENTS", "events", **event.__dict__)
+        save_event_to_json(event, filepath=self.config.neuron.events_json_log_path)
 
     # Log the event to wandb
     if not self.config.wandb.off and self.wandb is not None:
         wandb_event = EventSchema.from_dict(event.__dict__)
         self.wandb.log(asdict(wandb_event))
+
+
+def save_event_to_json(event, filepath="events_log.json"):
+    """Serialize the event to JSON and append it to a log file."""
+    with open(filepath, "a") as file:
+        json_event = json.dumps(event, default=lambda o: o.__dict__, ensure_ascii=False)
+        file.write(json_event + "\n")  # Write each event as a new line

--- a/storage/validator/weights.py
+++ b/storage/validator/weights.py
@@ -145,8 +145,13 @@ def set_weights_for_validator(
 
     if success is True:
         bt.logging.info("Set weights on chain successfully!")
+        best_idx = torch.argmax(torch.tensor(uint_weights)).item()
+        bt.logging.debug(f"Best index in set weights: {best_idx}")
 
-        best_uid = uint_uids[uint_weights.argmax()]
+        best_uid = uint_uids[best_idx]
+        bt.logging.debug(f"Best UID in set weights: {best_uid}")
+        bt.logging.debug(f"Best weight in set weights: {uint_weights[best_idx]}")
+
         event = EventSchema(
             task_name="SetWeights",
             successful=[],
@@ -157,7 +162,7 @@ def set_weights_for_validator(
             uids=uint_uids,
             step_length=0.0,
             best_uid=best_uid,
-            best_hotkey=metagraph.hotkeys.index(best_uid),
+            best_hotkey=metagraph.hotkeys[best_uid],
             rewards=[],
             set_weights=uint_weights,
         )

--- a/storage/validator/weights.py
+++ b/storage/validator/weights.py
@@ -21,8 +21,10 @@
 import torch
 import bittensor as bt
 
+from typing import Optional
 from storage import __spec_version__ as spec_version
 from storage.shared.weights import set_weights
+from storage.validator.event import EventSchema
 
 
 def set_weights_for_validator(
@@ -34,7 +36,7 @@ def set_weights_for_validator(
     wandb_on: bool = False,
     wait_for_inclusion: bool = False,
     wait_for_finalization: bool = False,
-):
+) -> Optional[EventSchema]:
     """
     Sets miners' weights on the Bittensor network.
 
@@ -143,5 +145,24 @@ def set_weights_for_validator(
 
     if success is True:
         bt.logging.info("Set weights on chain successfully!")
+
+        best_uid = uint_uids[uint_weights.argmax()]
+        event = EventSchema(
+            task_name="SetWeights",
+            successful=[],
+            completion_times=[],
+            task_status_messages=[],
+            task_status_codes=[],
+            block=subtensor.get_current_block(),
+            uids=uint_uids,
+            step_length=0.0,
+            best_uid=best_uid,
+            best_hotkey=metagraph.hotkeys.index(best_uid),
+            rewards=[],
+            set_weights=uint_weights,
+        )
+
+        return event
+
     else:
         bt.logging.error(f"Set weights failed {message}.")


### PR DESCRIPTION
This PR adds several QoL and introspection improvements on the validator side:

* Events logging to json
* Scatter plots of rewards and completion times
* Interactive 3D map versions of the above

To install the extra plot dependencies run:
`python -m pip install -r requirements.plot.txt`

Interactive map of rewards by task:
<img width="840" alt="Screenshot 2024-03-03 at 22 29 39" src="https://github.com/ifrit98/storage-subnet/assets/31426574/ed3cd70f-f963-4fdb-8b06-5dfc1b78c7ce">

Interactive map of Completions Time by task:
<img width="840" alt="Screenshot 2024-03-03 at 22 29 08" src="https://github.com/ifrit98/storage-subnet/assets/31426574/b1e68a61-9df8-411a-8653-3993e07e616e">

Heatmap of moving averaged scores:
<img width="858" alt="Screenshot 2024-03-03 at 22 30 10" src="https://github.com/ifrit98/storage-subnet/assets/31426574/e0b3dd55-1347-4cd6-afbe-3bac0af1c436">

