### PR TITLE
Reward/add top boost per batch

### DIFF
--- a/storage/constants.py
+++ b/storage/constants.py
@@ -26,3 +26,11 @@ SUPER_SAIYAN_WILSON_SCORE = 0.88
 DIAMOND_WILSON_SCORE = 0.77
 GOLD_WILSON_SCORE = 0.66
 SILVER_WILSON_SCORE = 0.55
+
+TIER_BOOSTS = {
+    b"Super Saiyan": 1.02, # 2%  -> 1.02
+    b"Diamond": 1.05,      # 5%  -> 0.945
+    b"Gold": 1.1,          # 10% -> 0.88
+    b"Silver": 1.15,       # 15% -> 0.805
+    b"Bronze": 1.2,        # 20% -> 0.72
+}

--- a/storage/validator/challenge.py
+++ b/storage/validator/challenge.py
@@ -176,6 +176,20 @@ async def challenge_data(self):
         self.device
     )
 
+    times = [
+        response.dendrite.process_time or 30
+        for response in responses
+    ]
+    bt.logging.debug(f"Dendrite Times: {times}")
+    sorted_times = sorted(list(zip(uids, times)), key=lambda x: x[1])
+
+    bt.logging.debug(f"Sorted Times: {sorted_times}")
+    in_top_2_dict = {
+        uid: True if time < 30 else False
+        for (uid, time) in sorted_times[:2]
+    }
+    bt.logging.debug(f"Is Top 2 Dict: {pformat(in_top_2_dict)}")
+
     remove_reward_idxs = []
     data_sizes = []
     for idx, (uid, (verified, response)) in enumerate(zip(uids, responses)):
@@ -207,7 +221,7 @@ async def challenge_data(self):
         )
 
         # Apply reward for this challenge
-        tier_factor = await get_tier_factor(hotkey, self.database)
+        tier_factor = await get_tier_factor(hotkey, self.database, in_top_2=in_top_2_dict.get(uid, False))
         rewards[idx] = 1.0 * tier_factor if verified else CHALLENGE_FAILURE_REWARD
 
         # Log the event data for this specific challenge

--- a/storage/validator/challenge.py
+++ b/storage/validator/challenge.py
@@ -177,7 +177,7 @@ async def challenge_data(self):
     )
 
     times = [
-        response[0].dendrite.process_time or 30
+        response[1].dendrite.process_time or 30
         for response in responses
     ]
     bt.logging.debug(f"Dendrite Times: {times}")

--- a/storage/validator/challenge.py
+++ b/storage/validator/challenge.py
@@ -177,7 +177,7 @@ async def challenge_data(self):
     )
 
     times = [
-        response.dendrite.process_time or 30
+        response[0].dendrite.process_time or 30
         for response in responses
     ]
     bt.logging.debug(f"Dendrite Times: {times}")

--- a/storage/validator/challenge.py
+++ b/storage/validator/challenge.py
@@ -177,7 +177,7 @@ async def challenge_data(self):
     )
 
     times = [
-        response[1].dendrite.process_time or 30
+        response[1][0].dendrite.process_time or 30
         for response in responses
     ]
     bt.logging.debug(f"Dendrite Times: {times}")

--- a/storage/validator/retrieve.py
+++ b/storage/validator/retrieve.py
@@ -164,7 +164,7 @@ async def retrieve_data(
 
     times = [
         response.dendrite.process_time or 60
-        for response in responses
+        for response, _, _ in response_tuples
     ]
     bt.logging.debug(f"Dendrite Times: {times}")
     sorted_times = sorted(list(zip(uids, times)), key=lambda x: x[1])
@@ -191,7 +191,7 @@ async def retrieve_data(
         data_sizes.append(sys.getsizeof(response.data))
 
         # Get the tier factor for this miner to determine the total reward
-        tier_factor = await get_tier_factor(hotkey, self.database, in_top_2=in_top_2_dict(uid, False))
+        tier_factor = await get_tier_factor(hotkey, self.database, in_top_2=in_top_2_dict.get(uid, False))
         try:
             decoded_data = base64.b64decode(response.data)
         except Exception as e:

--- a/storage/validator/retrieve.py
+++ b/storage/validator/retrieve.py
@@ -162,6 +162,20 @@ async def retrieve_data(
         len(response_tuples), dtype=torch.float32
     ).to(self.device)
 
+    times = [
+        response.dendrite.process_time or 60
+        for response in responses
+    ]
+    bt.logging.debug(f"Dendrite Times: {times}")
+    sorted_times = sorted(list(zip(uids, times)), key=lambda x: x[1])
+
+    bt.logging.debug(f"Sorted Times: {sorted_times}")
+    in_top_2_dict = {
+        uid: True if time < 60 else False
+        for (uid, time) in sorted_times[:2]
+    }
+    bt.logging.debug(f"Is Top 2 Dict: {pformat(in_top_2_dict)}")
+
     decoded_data = b""
     data_sizes = []
     for idx, (uid, (response, data_hash, seed)) in enumerate(
@@ -177,7 +191,7 @@ async def retrieve_data(
         data_sizes.append(sys.getsizeof(response.data))
 
         # Get the tier factor for this miner to determine the total reward
-        tier_factor = await get_tier_factor(hotkey, self.database)
+        tier_factor = await get_tier_factor(hotkey, self.database, in_top_2=in_top_2_dict(uid, False))
         try:
             decoded_data = base64.b64decode(response.data)
         except Exception as e:


### PR DESCRIPTION
Adds boost to top 2 miners per batch to accelerate tier ascension. This will help miners survive past immunity who are good performers and not be implicitly punished by older miners who are "grandfathered in"

