### PR TITLE
allow skipping Redis checks

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -131,17 +131,20 @@ class miner:
         bt.logging.info(f"{self.config}")
 
         redis_password = get_redis_password(self.config.database.redis_password)
-        try:
-            asyncio.run(check_environment(
-                self.config.database.redis_conf_path,
-                self.config.database.host,
-                self.config.database.port,
-                redis_password
-            ))
-        except AssertionError as e:
-            bt.logging.warning(
-                f"Something is missing in your environment: {e}. Please check your configuration, use the README for help, and try again."
-            )
+        if self.config.database.native_environment_check:
+            try:
+                asyncio.run(check_environment(
+                    self.config.database.redis_conf_path,
+                    self.config.database.host,
+                    self.config.database.port,
+                    redis_password
+                ))
+            except AssertionError as e:
+                bt.logging.warning(
+                    f"Something is missing in your environment: {e}. Please check your configuration, use the README for help, and try again."
+                )
+        else:
+            bt.logging.info("Skipping environment checks.")
 
         bt.logging.info("miner.__init__()")
 

--- a/storage/miner/config.py
+++ b/storage/miner/config.py
@@ -171,6 +171,13 @@ def add_args(cls, parser):
         help="Redis configuration path.",
         default="/etc/redis/redis.conf",
     )
+    parser.add_argument(
+        "--database.skip_native_environment_check",
+        dest="database.native_environment_check",
+        action="store_false",
+        default=True,
+        help="Skip native environment check.",
+    )
 
     # Run config.
     parser.add_argument(

--- a/storage/shared/checks.py
+++ b/storage/shared/checks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 import time
 import asyncio


### PR DESCRIPTION
The current code made some assumptions that Redis is always served from local machine AND is accessible through systemctl.
What was even worse for me, that it called `sudo` trying to access Redis service, which can block miner from starting since it requires user interaction.

So for users that know what they are doing, there is now an option to skip these checks.
