### PR TITLE
remove mistyped field name from required_hash_fields to prevent breakage with bittensor v7

### DIFF
--- a/storage/protocol.py
+++ b/storage/protocol.py
@@ -205,8 +205,9 @@ class Retrieve(FileTaoSynapseMixin, bt.Synapse):
     commitment_hash: typing.Optional[str] = None
     commitment_proof: typing.Optional[str] = None
 
+    # This should include `commitment_proof`, but it would require extensive changes to allow backwards compatibility.
     required_hash_fields: typing.List[str] = pydantic.Field(
-        ["data", "data_hash", "seed", "commtiment_proof", "commitment_hash"],
+        ["data", "data_hash", "seed", "commitment_hash"],
         title="Required Hash Fields",
         description="A list of required fields for the hash.",
         allow_mutation=False,


### PR DESCRIPTION
This has to be removed otherwise will break with bittensor v7 which includes https://github.com/opentensor/bittensor/pull/1818 (see description of that PR for exact reason why it will break).

In bittensor v6  the mistyped filenames in this field were silently ignored, which is why this was never detected before.